### PR TITLE
Updates for improved association handling

### DIFF
--- a/src/Superdesk/ContentApiSdk/ContentApiSdk.php
+++ b/src/Superdesk/ContentApiSdk/ContentApiSdk.php
@@ -174,16 +174,26 @@ class ContentApiSdk
         $associations = new stdClass();
 
         if (isset($package->associations)) {
-            foreach ($package->associations as $associatedName => $associatedItem) {
-                $associatedId = $this->getIdFromUri($associatedItem->uri);
+            foreach ($package->associations as $associationGroupName => $associationGroupItems) {
 
-                if ($associatedItem->type == 'composite') {
-                    $associatedObj = $this->getPackage($associatedId, true);
-                } else {
-                    $associatedObj = $this->getItem($associatedId);
+                $groupAssociations = new stdClass();
+
+                foreach ($associationGroupItems AS $associatedName => $associatedItem) {
+                    $associatedId = $this->getIdFromUri($associatedItem->uri);
+
+                    if ($associatedItem->type == 'picture') continue;
+
+                    if ($associatedItem->type == 'composite') {
+                        $associatedObj = $this->getPackage($associatedId, true);
+                    } else {
+                        $associatedObj = $this->getItem($associatedId);
+                        $associatedObj->type = $associatedItem->type;
+                    }
+
+                    $groupAssociations->$associatedName = $associatedObj;
                 }
 
-                $associations->$associatedName = $associatedObj;
+                $associations->$associationGroupName = $groupAssociations;
             }
         }
 

--- a/src/Superdesk/ContentApiSdk/ContentApiSdk.php
+++ b/src/Superdesk/ContentApiSdk/ContentApiSdk.php
@@ -27,6 +27,7 @@ class ContentApiSdk
 {
     const SUPERDESK_ENDPOINT_ITEMS = '/items';
     const SUPERDESK_ENDPOINT_PACKAGES = '/packages';
+    const PACKAGE_TYPE_COMPOSITE = 'composite';
 
     /**
      * A list of parameters the Content API accepts.
@@ -183,7 +184,7 @@ class ContentApiSdk
 
                     if ($associatedItem->type == 'picture') continue;
 
-                    if ($associatedItem->type == 'composite') {
+                    if ($associatedItem->type == self::PACKAGE_TYPE_COMPOSITE) {
                         $associatedObj = $this->getPackage($associatedId, true);
                     } else {
                         $associatedObj = $this->getItem($associatedId);

--- a/src/Superdesk/ContentApiSdk/ContentApiSdk.php
+++ b/src/Superdesk/ContentApiSdk/ContentApiSdk.php
@@ -18,6 +18,7 @@ use Superdesk\ContentApiSdk\Client\ClientInterface;
 use Superdesk\ContentApiSdk\Data\Item;
 use Superdesk\ContentApiSdk\Data\Package;
 use Superdesk\ContentApiSdk\Exception\InvalidDataException;
+use Superdesk\ContentApiSdk\Exception\ContentApiException;
 use stdClass;
 
 /**

--- a/src/Superdesk/ContentApiSdk/ContentApiSdk.php
+++ b/src/Superdesk/ContentApiSdk/ContentApiSdk.php
@@ -185,10 +185,16 @@ class ContentApiSdk
                     if ($associatedItem->type == 'picture') continue;
 
                     if ($associatedItem->type == self::PACKAGE_TYPE_COMPOSITE) {
-                        $associatedObj = $this->getPackage($associatedId, true);
+                        try {
+                            $associatedObj = $this->getPackage($associatedId, true);
+                        } catch (ContentApiException $e) {
+                        }
                     } else {
-                        $associatedObj = $this->getItem($associatedId);
-                        $associatedObj->type = $associatedItem->type;
+                        try {
+                            $associatedObj = $this->getItem($associatedId);
+                            $associatedObj->type = $associatedItem->type;
+                        } catch (ContentApiException $e) {
+                        }
                     }
 
                     $groupAssociations->$associatedName = $associatedObj;


### PR DESCRIPTION
Adds support for association categories and fixes item type. (Required due to update of Content API.)

The item type, when fully resolved from a package, will be set to the
same value as the value of the relation type between a package and an
item.
