### PR TITLE
SWP-77: Implements pagination for API collections via Pagerfanta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,11 @@
         }
     },
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "pagerfanta/pagerfanta": "1.0.3"
     },
     "require-dev": {
-        "phpspec/phpspec": "~2.0"
+        "phpspec/phpspec": "~2.3"
     },
     "scripts": {
     },

--- a/spec/Superdesk/ContentApiSdk/API/Pagerfanta/ItemAdapterSpec.php
+++ b/spec/Superdesk/ContentApiSdk/API/Pagerfanta/ItemAdapterSpec.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace spec\Superdesk\ContentApiSdk\API\Pagerfanta;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Superdesk\ContentApiSdk\Client\ClientInterface;
+use Superdesk\ContentApiSdk\API\Request;
+use Superdesk\ContentApiSdk\API\Response;
+use Superdesk\ContentApiSdk\Data\Item;
+
+class ItemAdapterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Superdesk\ContentApiSdk\API\Pagerfanta\ItemAdapter');
+    }
+
+    function let(ClientInterface $client, Request $request)
+    {
+        $this->beConstructedWith($client, $request);
+    }
+
+    function its_method_get_slice_should_return_items($client, $request)
+    {
+        $response = new Response('{"_links": {"self": {"title": "items", "href": "items?start_date=2015-01-01&max_results=2&page=1"}, "parent": {"title": "home", "href": "/"}}, "_meta": {"total": 2, "max_results": 2, "page": 1}, "_items": [{"headline": "Andromeda on a collision course", "body_text": "Andromeda and Milky Way will collide in about 2 billion years", "_links": {"self": {"title": "Item", "href": "items/tag:example.com,0001:newsml_BRE9A607"}}, "versioncreated": "2015-03-09T16:32:23+0000", "pubstatus": "usable", "version": "2", "uri": "http://api.master.dev.superdesk.org/items/tag%3Aexample.com%2C0001%3Anewsml_BRE9A607", "_type": "items", "language": "en", "type": "text"}, {"headline": "Die Lore-Ley", "body_text": "Ich wei\u00df nicht was soll es bedeuten", "_links": {"self": {"title": "Item", "href": "items/tag:example.com,0001:newsml_BRE9A608"}}, "versioncreated": "2015-04-19T13:45:54+0000", "pubstatus": "usable", "version": "3", "uri": "http://api.master.dev.superdesk.org/items/tag%3Aexample.com%2C0001%3Anewsml_BRE9A608", "_type": "items", "language": "de", "type": "text"}]}');
+        $client->makeApiCall($request)->willReturn($response);
+        $this->getSlice(1, 1)->shouldContainItems();
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'containItems' => function ($items) {
+                foreach ($items as $item) {
+                    if (!$item instanceof Item) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        ];
+    }
+}

--- a/spec/Superdesk/ContentApiSdk/API/Pagerfanta/ItemAdapterSpec.php
+++ b/spec/Superdesk/ContentApiSdk/API/Pagerfanta/ItemAdapterSpec.php
@@ -42,7 +42,7 @@ class ItemAdapterSpec extends ObjectBehavior
 
     public function getMatchers()
     {
-        return [
+        return array(
             'containItems' => function ($items) {
                 foreach ($items as $item) {
                     if (!$item instanceof Item) {
@@ -51,6 +51,6 @@ class ItemAdapterSpec extends ObjectBehavior
                 }
                 return true;
             }
-        ];
+        );
     }
 }

--- a/spec/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapterSpec.php
+++ b/spec/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapterSpec.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace spec\Superdesk\ContentApiSdk\API\Pagerfanta;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Superdesk\ContentApiSdk\Client\ClientInterface;
+use Superdesk\ContentApiSdk\API\Request;
+use Superdesk\ContentApiSdk\API\Response;
+use Superdesk\ContentApiSdk\Data\Package;
+use Superdesk\ContentApiSdk\ContentApiSdk;
+
+class PackageAdapterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Superdesk\ContentApiSdk\API\Pagerfanta\PackageAdapter');
+    }
+
+    function let(ClientInterface $client, Request $request, ContentApiSdk $sdk)
+    {
+        $resolveAssociations = false;
+        $this->beConstructedWith($client, $request, $sdk, $resolveAssociations);
+    }
+
+    function its_method_get_slice_should_return_items($client, $request, $sdk, $resolveAssociations)
+    {
+        $response = new Response('{"_meta": {"max_results": 2, "total": 45, "page": 3}, "_links": {"self": {"title": "packages", "href": "packages?start_date=2015-01-01&max_results=2&page=3"}, "parent": {"title": "home", "href": "/"}, "next": {"title": "next page", "href": "packages?max_results=2&page=4"}, "prev": {"title": "previous page", "href": "packages?max_results=2&page=2"}, "last": {"title": "last page", "href": "packages?max_results=2&page=23"}}, "_items": [{"body_html": "<p>SAUDI-LED COALITION SPOKESMAN SAYS COALITION JETS WERE IN ACTION\nIN SAADA GOVERNORATE, BUT NOT INSIDE CITY</p>", "pubstatus": "usable", "subject": [{"qcode": "16009000", "name": "war"}, {"qcode": "11002000", "name": "diplomacy"}, {"qcode": "10000000", "name": "lifestyle and leisure"}, {"qcode": "11000000", "name": "politics"}, {"qcode": "16000000", "name": "unrest, conflicts and  war"}], "uri": "http://api.master.dev.superdesk.org/packages/urn%3Anewsml%3Alocalhost%3A2015-10-27T17%3A53%3A17.408024%3Aa53e9fb0-d43e-41a4-a767-0dddaa549842", "headline": "SAUDI-LED COALITION SPOKESMAN SAYS CO", "priority": 1, "associations": {"main": [{"uri": "http://api.master.dev.superdesk.org/items/tag%3Alocalhost%3A2015%3A120dfa7c-62eb-40c4-8972-7e0d41e3c220", "type": "text"}]}, "_type": "items", "version": 2, "_links": {"self": {"title": "Package", "href": "packages/urn:newsml:localhost:2015-10-27T17:53:17.408024:a53e9fb0-d43e-41a4-a767-0dddaa549842"}}, "urgency": 1, "language": "en", "versioncreated": "2015-10-27T17:53:17+0000", "byline": "mkk", "located": "Santa Fe", "type": "composite"}, {"body_html": "<p>NAREG DARWIN</p>", "pubstatus": "usable", "subject": [{"qcode": "01001000", "parent": "01000000", "name": "archaeology"}], "uri": "http://api.master.dev.superdesk.org/packages/urn%3Anewsml%3Alocalhost%3A2015-10-27T21%3A26%3A35.366266%3Acbdb917d-5e5e-4796-b384-c784baa766d2", "headline": "NAREG DARWIN", "priority": 1, "associations": {"main": [{"uri": "http://api.master.dev.superdesk.org/items/urn%3Anewsml%3Alocalhost%3A2015-10-27T21%3A26%3A07.748901%3A49745a57-04d8-4645-8e63-b3a06f2ca36b", "type": "text"}]}, "_type": "items", "version": 2, "_links": {"self": {"title": "Package", "href": "packages/urn:newsml:localhost:2015-10-27T21:26:35.366266:cbdb917d-5e5e-4796-b384-c784baa766d2"}}, "urgency": 1, "language": "en", "versioncreated": "2015-10-27T21:26:35+0000", "byline": "N", "located": "Holdfast Bay", "type": "composite"}]}');
+        $client->makeApiCall($request)->willReturn($response);
+        $this->getSlice(1, 1)->shouldContainPackages();
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'containPackages' => function ($packages) {
+                foreach ($packages as $package) {
+                    if (!$package instanceof Package) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        ];
+    }
+}

--- a/spec/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapterSpec.php
+++ b/spec/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapterSpec.php
@@ -44,7 +44,7 @@ class PackageAdapterSpec extends ObjectBehavior
 
     public function getMatchers()
     {
-        return [
+        return array(
             'containPackages' => function ($packages) {
                 foreach ($packages as $package) {
                     if (!$package instanceof Package) {
@@ -53,6 +53,6 @@ class PackageAdapterSpec extends ObjectBehavior
                 }
                 return true;
             }
-        ];
+        );
     }
 }

--- a/spec/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapterSpec.php
+++ b/spec/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapterSpec.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace spec\Superdesk\ContentApiSdk\API\Pagerfanta;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Superdesk\ContentApiSdk\Client\ClientInterface;
+use Superdesk\ContentApiSdk\API\Request;
+
+class ResourceAdapterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Superdesk\ContentApiSdk\API\Pagerfanta\ResourceAdapter');
+    }
+
+    function let(ClientInterface $client, Request $request)
+    {
+        $this->beConstructedWith($client, $request);
+    }
+}

--- a/spec/Superdesk/ContentApiSdk/API/RequestSpec.php
+++ b/spec/Superdesk/ContentApiSdk/API/RequestSpec.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace spec\Superdesk\ContentApiSdk\API;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Superdesk\ContentApiSdk\ContentApiSdk;
+
+class RequestSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Superdesk\ContentApiSdk\API\Request');
+    }
+
+    function let()
+    {
+        $this->beConstructedWith('example.com', '/request/uri', array('start_date' => '1970-01-01'), 80);
+    }
+
+    function it_should_return_a_base_url()
+    {
+        $this->getBaseUrl()->shouldBe('https://example.com:80/v1');
+    }
+
+    function it_should_return_a_full_url()
+    {
+        $this->getFullUrl()->shouldBe('https://example.com:80/v1/request/uri?start_date=1970-01-01');
+    }
+
+    function it_should_validate_parameters_on_request()
+    {
+        $parameters = array('some_key' => 'some value', 'start_date' => '1970-01-01');
+
+        $this->enableParameterValidation();
+        $this->setParameters($parameters)->getParameters()->shouldBe(array('start_date' => '1970-01-01'));
+
+        $this->disableParameterValidation();
+        $this->setParameters($parameters)->getParameters()->shouldBe($parameters);
+    }
+
+    function its_method_set_parameters_should_throw_an_exception()
+    {
+        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\RequestException')->duringSetParameters(array('start_date' => array()), true);
+    }
+}

--- a/spec/Superdesk/ContentApiSdk/API/ResponseSpec.php
+++ b/spec/Superdesk/ContentApiSdk/API/ResponseSpec.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace spec\Superdesk\ContentApiSdk\API;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Superdesk\ContentApiSdk\ContentApiSdk;
+use Superdesk\ContentApiSdk\API\Response;
+
+class ResponseSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Superdesk\ContentApiSdk\API\Response');
+    }
+
+    function let()
+    {
+        $this->beConstructedWith(
+            '{"_meta": {"max_results": 2, "total": 45, "page": 3}, "_links": {"self": {"title": "packages", "href": "packages?start_date=2015-01-01&max_results=2&page=3"}, "parent": {"title": "home", "href": "/"}, "next": {"title": "next page", "href": "packages?max_results=2&page=4"}, "prev": {"title": "previous page", "href": "packages?max_results=2&page=2"}, "last": {"title": "last page", "href": "packages?max_results=2&page=23"}}, "_items": [{"body_html": "<p>SAUDI-LED COALITION SPOKESMAN SAYS COALITION JETS WERE IN ACTION\nIN SAADA GOVERNORATE, BUT NOT INSIDE CITY</p>", "pubstatus": "usable", "subject": [{"qcode": "16009000", "name": "war"}, {"qcode": "11002000", "name": "diplomacy"}, {"qcode": "10000000", "name": "lifestyle and leisure"}, {"qcode": "11000000", "name": "politics"}, {"qcode": "16000000", "name": "unrest, conflicts and  war"}], "uri": "http://api.master.dev.superdesk.org/packages/urn%3Anewsml%3Alocalhost%3A2015-10-27T17%3A53%3A17.408024%3Aa53e9fb0-d43e-41a4-a767-0dddaa549842", "headline": "SAUDI-LED COALITION SPOKESMAN SAYS CO", "priority": 1, "associations": {"main": [{"uri": "http://api.master.dev.superdesk.org/items/tag%3Alocalhost%3A2015%3A120dfa7c-62eb-40c4-8972-7e0d41e3c220", "type": "text"}]}, "_type": "items", "version": 2, "_links": {"self": {"title": "Package", "href": "packages/urn:newsml:localhost:2015-10-27T17:53:17.408024:a53e9fb0-d43e-41a4-a767-0dddaa549842"}}, "urgency": 1, "language": "en", "versioncreated": "2015-10-27T17:53:17+0000", "byline": "mkk", "located": "Santa Fe", "type": "composite"}, {"body_html": "<p>NAREG DARWIN</p>", "pubstatus": "usable", "subject": [{"qcode": "01001000", "parent": "01000000", "name": "archaeology"}], "uri": "http://api.master.dev.superdesk.org/packages/urn%3Anewsml%3Alocalhost%3A2015-10-27T21%3A26%3A35.366266%3Acbdb917d-5e5e-4796-b384-c784baa766d2", "headline": "NAREG DARWIN", "priority": 1, "associations": {"main": [{"uri": "http://api.master.dev.superdesk.org/items/urn%3Anewsml%3Alocalhost%3A2015-10-27T21%3A26%3A07.748901%3A49745a57-04d8-4645-8e63-b3a06f2ca36b", "type": "text"}]}, "_type": "items", "version": 2, "_links": {"self": {"title": "Package", "href": "packages/urn:newsml:localhost:2015-10-27T21:26:35.366266:cbdb917d-5e5e-4796-b384-c784baa766d2"}}, "urgency": 1, "language": "en", "versioncreated": "2015-10-27T21:26:35+0000", "byline": "N", "located": "Holdfast Bay", "type": "composite"}]}',
+            array(
+                'Connection' => 'keep-alive',
+                'Content-Encoding' => 'gzip',
+                'Content-Type' => 'application/json',
+                'Date' => 'Wed, 11 Nov 2015 13:56:14 GMT',
+                'Last-Modified' => 'Mon, 02 Nov 2015 21:15:26 GMT',
+                'Server' => 'nginx',
+                'Transfer-Encoding' => 'chunked',
+                'Vary' => 'Accept-Encoding, Accept-Encoding',
+                'X-Total-Count' => '45'
+            )
+        );
+    }
+
+    function it_should_support_json_content_type_via_header()
+    {
+        $this->getContentType()->shouldBe(Response::CONTENT_TYPE_JSON);
+    }
+
+    function it_should_support_json_content_type_via_content_snooping()
+    {
+        $this->beConstructedWith(
+            '{"_meta": {"max_results": 1, "total": 45, "page": 1}, "_links": {"self": {"title": "packages", "href": "packages?start_date=2015-01-01&max_results=1"}, "parent": {"title": "home", "href": "/"}, "next": {"title": "next page", "href": "packages?max_results=1&page=2"}, "last": {"title": "last page", "href": "packages?max_results=1&page=45"}}, "_items": [{"headline": "Reuters Sports News Summary", "pubstatus": "usable", "type": "composite", "body_html": "<p>Following is a summary of current sports news briefs.</p>\n<p>Serena to start 2016 at Hopman Cup in Perth</p>\n<p>World number one Serena Williams will again launch her\nseason at the Hopman Cup in Australia, tournament organizers\nsaid on Wednesday. Williams reached the final of the mixed team\nevent last year with American compatriot John Isner to kick off\na superb season where she won the Australian and French Opens\nand Wimbledon to take her grand slam singles haul to 21.</p>\n<p>In a series hole, Cubs vow to keep swinging</p>\n<p>History has not often been kind to the Cubs, Chicago\'s\npopular but seldom successful north side baseball franchise, but\nthe young team remains hopeful they can continue their\npost-season run. The Cubs survived a one-game playoff to earn a\nspot in the National League\'s divisional series, where they\ndispatched the arch rival St. Louis Cardinals.</p>\n<p>NBA player accuses Milwaukee-area jeweler of racial\nprofiling</p>\n<p>Milwaukee Bucks forward John Henson has accused a\nMilwaukee-area jeweler of racial profiling after its employees\nlocked him out and called police when he went to the store to\nbuy a watch on Monday afternoon. The president of\nSchwanke-Kasten Jewelers issue a statement Monday night\napologizing for the incident at the store in Whitefish Bay, a\nnorthern suburb of Milwaukee.</p>\n<p>Royals rout Jays, one win from World Series berth</p>\n<p>The Kansas City Royals pounced early then powered their way\nto a 14-2 demolition of the Toronto Blue Jays on Tuesday to move\none win away from reaching the World Series for a second\nconsecutive year. The Royals, with the help of a two-run homer\nfrom Ben Zobrist, scored four runs in the first inning then\nsealed the victory with a four-run seventh to seize a commanding\n3-1 lead in the best-of-seven American League Championship\nSeries.</p>\n<p>Mets beat Cubs, one win away from World Series</p>\n<p>The New York Mets snapped a 2-2 tie on a wild-pitch\nstrikeout  on the way to beating the Chicago Cubs 5-2 on\nTuesday, putting them one win away from the World Series. The\nvictory, keyed by the strong pitching of Jacob deGrom and\nanother home run by Daniel Murphy, gave New York a 3-0 lead in\nthe best-of-seven National League Championship Series.</p>\n<p>Yankees\' Tanaka has elbow surgery, will return in 2016</p>\n<p>Japanese right-hander Masahiro Tanaka had surgery on Tuesday\nto remove a bone spur in his pitching elbow and is expected to\nbe ready for the 2016 Major League Baseball season, the New York\nYankees said. The bone spur was pre-existing and dated back to\nTanaka\'s stellar pitching career in his native Japan, according\nto the Yankees.</p>\n<p>Blackhawks\' Keith out 4-6 weeks after knee surgery</p>\n<p>Three-times Stanley Cup-winning Chicago Blackhawks\ndefenseman Duncan Keith is expected to be sidelined between four\nand six weeks after having knee surgery on Tuesday, the National\nHockey League team said. Keith, a three-times All-Star who won\nOlympic gold with Canada at both the 2010 and 2014 Winter Games,\nhad a procedure to repair a meniscal tear in his right knee.</p>\n<p>Lamar Odom making \'incredible strides,\' Khloe Kardashian\nsays</p>\n<p>Reality TV star Khloe Kardashian said on Tuesday her\nestranged husband Lamar Odom has made \"incredible strides\" as he\nrecovers from a collapse in a Las Vegas brothel last week, while\nthe former NBA player\'s aunt called his progress \"miraculous.\"\nBreaking her silence, Kardashian also thanked fans and staff at\nthe Sunrise Hospital in Las Vegas for their support during what\nshe called \"an incredibly difficult\" week.</p>\n<p>NY federal prosecutor probes daily fantasy sports business:\nWSJ</p>\n<p>Manhattan Attorney Preet Bharara is investigating whether\nthe business model behind daily fantasy sports companies such as\nDraftKings Inc and FanDuel Inc violates federal law, the Wall\nStreet Journal reported. The investigation is at an early stage\nand senior Justice Department lawyers in Washington are\nundecided on whether daily fantasy sports betting violates\nfederal gambling statutes, the newspaper reported, citing people\nfamiliar with the matter.</p>\n<p>Royal Rios gives Blue Jays fans more reason to boo</p>\n<p>Former Blue Jay Alex Rios has been the main target of\nToronto fans\' hostility during the American League Championship\nSeries and on Tuesday the big Kansas City outfielder gave them\nmore reason to jeer. Rios collected three hits, including a\nsecond-inning solo home run, as the Royals hammered the Blue\nJays 14-2 to take a 3-1 lead in the best-of-seven series,\nleaving Kansas City one win away from a return to the World\nSeries.</p>", "uri": "http://api.master.dev.superdesk.org/packages/urn%3Anewsml%3Alocalhost%3A2015-10-21T08%3A15%3A23.368872%3A570e1485-b572-48d8-a067-daf47cb62755", "subject": [{"qcode": "01021001", "parent": "01021000", "name": "entertainment award"}], "priority": 2, "associations": {"main": [{"uri": "http://api.master.dev.superdesk.org/items/tag%3Alocalhost%3A2015%3Abd80492e-f770-4230-9cef-a4ee52b43b69", "type": "text"}]}, "_type": "items", "version": 2, "_links": {"self": {"title": "Package", "href": "packages/urn:newsml:localhost:2015-10-21T08:15:23.368872:570e1485-b572-48d8-a067-daf47cb62755"}}, "urgency": 3, "language": "en", "versioncreated": "2015-10-21T08:15:23+0000", "byline": "me", "located": "Taloqan"}]}',
+            array()
+        );
+        $this->getContentType()->shouldBe(Response::CONTENT_TYPE_JSON);
+    }
+
+    function it_should_support_xml_content_type_via_header()
+    {
+        $this->beConstructedWith(
+            '<?xml version="1.0" encoding=UTF-8 standalone="no" ?><error Borked xml <error>',
+            array('Content-Type' => Response::CONTENT_TYPE_XML)
+        );
+        $this->getContentType()->shouldBe(Response::CONTENT_TYPE_XML);
+    }
+
+    function it_should_support_xml_content_type_via_content_snooping()
+    {
+        $this->beConstructedWith(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no" ?><validxml>This is valid xml.</validxml>',
+            array()
+        );
+        $this->getContentType()->shouldBe(Response::CONTENT_TYPE_XML);
+    }
+
+    function it_should_throw_an_exception_on_content_type_determination_errors()
+    {
+        $this->beConstructedWith(
+            '{ "some key" : "borked json }',
+            array()
+        );
+        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ResponseException')->duringInstantiation();
+
+        $this->beConstructedWith(
+            '<?xml version="1.0" encoding=UTF-8 standalone="no" ?><error Borked xml <error>',
+            array()
+        );
+        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ResponseException')->duringInstantiation();
+
+        $this->beConstructedWith(
+            '',
+            array()
+        );
+        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ResponseException')->duringInstantiation();
+    }
+
+    function it_converts_a_collection_response_properly()
+    {
+        $this->getType()->shouldBe('packages');
+        $this->getHref()->shouldBe('packages?start_date=2015-01-01&max_results=2&page=3');
+        $this->getCurrentPage()->shouldBe(3);
+        $this->getNextPage()->shouldBe(4);
+        $this->getPreviousPage()->shouldBe(2);
+        $this->getLastPage()->shouldBe(23);
+        $this->getTotalResults()->shouldBe(45);
+
+        $this->getResources()->shouldBeArray();
+        $this->getResources()->shouldHaveCount(2);
+
+        $this->isFirstPage()->shouldBe(false);
+        $this->isLastPage()->shouldBe(false);
+    }
+
+    function it_converts_a_single_response_properly()
+    {
+        $jsonBody = '{"headline": "foo bar", "version": "1", "type": "composite", "versioncreated": "2015-02-10T06:49:47+0000", "_links": {"parent": {"title": "home", "href": "/"}, "collection": {"title": "packages", "href": "packages"}, "self": {"title": "Package", "href": "packages/tag:example.com,0001:newsml_BRE9A606"}}, "pubstatus": "usable", "language": "en", "uri": "http://api.master.dev.superdesk.org/packages/tag%3Aexample.com%2C0001%3Anewsml_BRE9A606"}';
+        $jsonObj = json_decode($jsonBody);
+        $this->beConstructedWith(
+            $jsonBody,
+            array(
+                'Connection' => 'keep-alive',
+                'Content-Encoding' => 'gzip',
+                'Content-Type' => 'application/json',
+                'Date' => 'Wed, 11 Nov 2015 13:56:14 GMT',
+                'Last-Modified' => 'Mon, 02 Nov 2015 21:15:26 GMT',
+                'Server' => 'nginx',
+                'Transfer-Encoding' => 'chunked',
+                'Vary' => 'Accept-Encoding, Accept-Encoding',
+                'X-Total-Count' => '45'
+            )
+        );
+
+        $this->getType()->shouldBe('Package');
+        $this->getHref()->shouldBe('packages/tag:example.com,0001:newsml_BRE9A606');
+        $this->getCurrentPage()->shouldBe(null);
+        $this->getNextPage()->shouldBe(null);
+        $this->getPreviousPage()->shouldBe(null);
+        $this->getLastPage()->shouldBe(null);
+        $this->getTotalResults()->shouldBe(null);
+
+        $resource = $this->getResources();
+        $resource->shouldBeAnInstanceOf('\stdClass');
+
+        foreach ($jsonObj as $property => $value) {
+            if ($property == '_links') continue;
+            $resource->shouldHaveProperty($property);
+        }
+
+        // TODO: Should i care about this...
+        // $this->isFirstPage()->shouldBe(false);
+        // $this->isLastPage()->shouldBe(false);
+    }
+
+    function its_method_is_first_page_should_work()
+    {
+        $this->beConstructedWith(
+            '{"_meta": {"max_results": 2, "total": 45, "page": 1}, "_links": {"self": {"title": "packages", "href": "packages?start_date=2015-01-01&max_results=2&page=1"}, "parent": {"title": "home", "href": "/"}, "next": {"title": "next page", "href": "packages?max_results=2&page=2"}, "last": {"title": "last page", "href": "packages?max_results=2&page=23"}}, "_items": [{"headline": "Reuters Sports News Summary", "pubstatus": "usable", "type": "composite", "body_html": "<p>Following is a summary of current sports news briefs.</p>\n<p>Serena to start 2016 at Hopman Cup in Perth</p>\n<p>World number one Serena Williams will again launch her\nseason at the Hopman Cup in Australia, tournament organizers\nsaid on Wednesday. Williams reached the final of the mixed team\nevent last year with American compatriot John Isner to kick off\na superb season where she won the Australian and French Opens\nand Wimbledon to take her grand slam singles haul to 21.</p>\n<p>In a series hole, Cubs vow to keep swinging</p>\n<p>History has not often been kind to the Cubs, Chicago\'s\npopular but seldom successful north side baseball franchise, but\nthe young team remains hopeful they can continue their\npost-season run. The Cubs survived a one-game playoff to earn a\nspot in the National League\'s divisional series, where they\ndispatched the arch rival St. Louis Cardinals.</p>\n<p>NBA player accuses Milwaukee-area jeweler of racial\nprofiling</p>\n<p>Milwaukee Bucks forward John Henson has accused a\nMilwaukee-area jeweler of racial profiling after its employees\nlocked him out and called police when he went to the store to\nbuy a watch on Monday afternoon. The president of\nSchwanke-Kasten Jewelers issue a statement Monday night\napologizing for the incident at the store in Whitefish Bay, a\nnorthern suburb of Milwaukee.</p>\n<p>Royals rout Jays, one win from World Series berth</p>\n<p>The Kansas City Royals pounced early then powered their way\nto a 14-2 demolition of the Toronto Blue Jays on Tuesday to move\none win away from reaching the World Series for a second\nconsecutive year. The Royals, with the help of a two-run homer\nfrom Ben Zobrist, scored four runs in the first inning then\nsealed the victory with a four-run seventh to seize a commanding\n3-1 lead in the best-of-seven American League Championship\nSeries.</p>\n<p>Mets beat Cubs, one win away from World Series</p>\n<p>The New York Mets snapped a 2-2 tie on a wild-pitch\nstrikeout  on the way to beating the Chicago Cubs 5-2 on\nTuesday, putting them one win away from the World Series. The\nvictory, keyed by the strong pitching of Jacob deGrom and\nanother home run by Daniel Murphy, gave New York a 3-0 lead in\nthe best-of-seven National League Championship Series.</p>\n<p>Yankees\' Tanaka has elbow surgery, will return in 2016</p>\n<p>Japanese right-hander Masahiro Tanaka had surgery on Tuesday\nto remove a bone spur in his pitching elbow and is expected to\nbe ready for the 2016 Major League Baseball season, the New York\nYankees said. The bone spur was pre-existing and dated back to\nTanaka\'s stellar pitching career in his native Japan, according\nto the Yankees.</p>\n<p>Blackhawks\' Keith out 4-6 weeks after knee surgery</p>\n<p>Three-times Stanley Cup-winning Chicago Blackhawks\ndefenseman Duncan Keith is expected to be sidelined between four\nand six weeks after having knee surgery on Tuesday, the National\nHockey League team said. Keith, a three-times All-Star who won\nOlympic gold with Canada at both the 2010 and 2014 Winter Games,\nhad a procedure to repair a meniscal tear in his right knee.</p>\n<p>Lamar Odom making \'incredible strides,\' Khloe Kardashian\nsays</p>\n<p>Reality TV star Khloe Kardashian said on Tuesday her\nestranged husband Lamar Odom has made \"incredible strides\" as he\nrecovers from a collapse in a Las Vegas brothel last week, while\nthe former NBA player\'s aunt called his progress \"miraculous.\"\nBreaking her silence, Kardashian also thanked fans and staff at\nthe Sunrise Hospital in Las Vegas for their support during what\nshe called \"an incredibly difficult\" week.</p>\n<p>NY federal prosecutor probes daily fantasy sports business:\nWSJ</p>\n<p>Manhattan Attorney Preet Bharara is investigating whether\nthe business model behind daily fantasy sports companies such as\nDraftKings Inc and FanDuel Inc violates federal law, the Wall\nStreet Journal reported. The investigation is at an early stage\nand senior Justice Department lawyers in Washington are\nundecided on whether daily fantasy sports betting violates\nfederal gambling statutes, the newspaper reported, citing people\nfamiliar with the matter.</p>\n<p>Royal Rios gives Blue Jays fans more reason to boo</p>\n<p>Former Blue Jay Alex Rios has been the main target of\nToronto fans\' hostility during the American League Championship\nSeries and on Tuesday the big Kansas City outfielder gave them\nmore reason to jeer. Rios collected three hits, including a\nsecond-inning solo home run, as the Royals hammered the Blue\nJays 14-2 to take a 3-1 lead in the best-of-seven series,\nleaving Kansas City one win away from a return to the World\nSeries.</p>", "uri": "http://api.master.dev.superdesk.org/packages/urn%3Anewsml%3Alocalhost%3A2015-10-21T08%3A15%3A23.368872%3A570e1485-b572-48d8-a067-daf47cb62755", "subject": [{"qcode": "01021001", "parent": "01021000", "name": "entertainment award"}], "priority": 2, "associations": {"main": [{"uri": "http://api.master.dev.superdesk.org/items/tag%3Alocalhost%3A2015%3Abd80492e-f770-4230-9cef-a4ee52b43b69", "type": "text"}]}, "_type": "items", "version": 2, "_links": {"self": {"title": "Package", "href": "packages/urn:newsml:localhost:2015-10-21T08:15:23.368872:570e1485-b572-48d8-a067-daf47cb62755"}}, "urgency": 3, "language": "en", "versioncreated": "2015-10-21T08:15:23+0000", "byline": "me", "located": "Taloqan"}, {"_links": {"self": {"title": "Package", "href": "packages/urn:newsml:localhost:2015-10-23T00:47:27.782815:2cb29e8e-cf5c-4304-8fe9-cecc071cbfc9"}}, "body_html": "<p>A dirty, dirty, dirty man has been torn in half in a car crash in Sydney\'s CBD. I srrely can. Wait a bit for mou spellingh mistook.</p><p><br></p><p><br></p><br><p>Father Vince Ryannisha&nbsp;the third discovered the man\'s body.</p><p><br></p><br><p>\"E\'s not in a good way,\" the passer-by said.</p><p>\"I reckon he will be put in a coffin in bits.\"</p><p><br></p>", "pubstatus": "usable", "type": "composite", "subject": [{"qcode": "03000000", "parent": null, "name": "disaster and accident"}], "uri": "http://api.master.dev.superdesk.org/packages/urn%3Anewsml%3Alocalhost%3A2015-10-23T00%3A47%3A27.782815%3A2cb29e8e-cf5c-4304-8fe9-cecc071cbfc9", "headline": "Dirty priest brown bread following NSW car\u00a0crash", "priority": 3, "associations": {"main": [{"uri": "http://api.master.dev.superdesk.org/items/urn%3Anewsml%3Alocalhost%3A2015-10-23T00%3A42%3A18.286510%3Af9a80c4c-76a1-4d5b-b309-ee118dc249d0", "type": "text"}, {"uri": "http://api.master.dev.superdesk.org/items/urn%3Anewsml%3Alocalhost%3A2015-10-23T00%3A47%3A27.730247%3A04af9b68-873c-4637-ae4f-12462e3742de", "type": "text"}, {"uri": "http://api.master.dev.superdesk.org/items/urn%3Anewsml%3Alocalhost%3A2015-10-23T00%3A49%3A03.408391%3A02fd0417-c58d-4288-9197-ca7073972c9f", "type": "text"}]}, "versioncreated": "2015-10-23T00:49:03+0000", "_type": "items", "version": 5, "place": [{"qcode": "NSW", "group": "Australia", "country": "Australia", "world_region": "Oceania", "name": "NSW", "state": "New South Wales"}], "urgency": 3, "language": "en", "byline": "", "located": "Fayzabad"}]}',
+            array()
+        );
+        $this->isFirstPage()->shouldBe(true);
+    }
+
+    function its_method_is_last_page_should_work()
+    {
+        $this->beConstructedWith(
+            '{"_meta": {"max_results": 2, "total": 45, "page": 23}, "_links": {"self": {"title": "packages", "href": "packages?start_date=2015-01-01&max_results=2&page=23"}, "parent": {"title": "home", "href": "/"}, "prev": {"title": "previous page", "href": "packages?max_results=2&page=22"}}, "_items": [{"pubstatus": "usable", "subject": [{"qcode": "01001000", "parent": "01000000", "name": "archaeology"}], "uri": "http://api.master.dev.superdesk.org/packages/urn%3Anewsml%3Alocalhost%3A2015-11-02T20%3A45%3A44.547837%3A1a1b9503-f958-4948-81a5-bd1db05e3047", "headline": "head", "priority": 1, "associations": {"main": [{"uri": "http://api.master.dev.superdesk.org/items/urn%3Anewsml%3Alocalhost%3A2015-11-02T20%3A44%3A27.205913%3A72694f6c-a2a2-4e39-af3a-f4a57ab2b3c1", "type": "video"}]}, "_type": "items", "version": 4, "_links": {"self": {"title": "Package", "href": "packages/urn:newsml:localhost:2015-11-02T20:45:44.547837:1a1b9503-f958-4948-81a5-bd1db05e3047"}}, "urgency": 3, "description_text": "desc", "slugline": "slug", "language": "en", "versioncreated": "2015-11-02T20:47:39+0000", "byline": "N", "located": "Holdfast Bay", "type": "composite"}]}',
+            array()
+        );
+        $this->isLastPage()->shouldBe(true);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'haveProperty' => function ($object, $property) {
+                return property_exists($object, $property);
+            }
+        ];
+    }
+}

--- a/spec/Superdesk/ContentApiSdk/API/ResponseSpec.php
+++ b/spec/Superdesk/ContentApiSdk/API/ResponseSpec.php
@@ -174,10 +174,10 @@ class ResponseSpec extends ObjectBehavior
 
     public function getMatchers()
     {
-        return [
+        return array(
             'haveProperty' => function ($object, $property) {
                 return property_exists($object, $property);
             }
-        ];
+        );
     }
 }

--- a/spec/Superdesk/ContentApiSdk/Client/FileGetContentsClientHelperSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Client/FileGetContentsClientHelperSpec.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace spec\Superdesk\ContentApiSdk\Client;
+
+use PhpSpec\ObjectBehavior;
+use Superdesk\ContentApiSdk\API\Request;
+use Superdesk\ContentApiSdk\API\Response;
+use Superdesk\ContentApiSdk\Client\FileGetContentsClient;
+
+class FileGetContentsClientHelperSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Superdesk\ContentApiSdk\Client\FileGetContentsClientHelper');
+    }
+
+    function it_should_make_a_call_to_a_remote_server($request)
+    {
+        $this->sendRequest('http://httpbin.org/status/200', array())->shouldHaveKey('headers');
+        $this->sendRequest('http://httpbin.org/status/200', array())->shouldHaveKeyWithValue('body', '');
+    }
+
+    function it_should_throw_an_exception_when_an_error_occurs()
+    {
+        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ClientException')->duringSendRequest('http://httpbin.org/status/404', array());
+        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ClientException')->duringSendRequest('http://httpbin.org/status/500', array());
+    }
+}

--- a/spec/Superdesk/ContentApiSdk/Client/FileGetContentsClientSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Client/FileGetContentsClientSpec.php
@@ -15,81 +15,54 @@
 namespace spec\Superdesk\ContentApiSdk\Client;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Superdesk\ContentApiSdk\API\Request;
+use Superdesk\ContentApiSdk\API\Response;
+use Superdesk\ContentApiSdk\Client\FileGetContentsClient;
+use Superdesk\ContentApiSdk\Client\FileGetContentsClientHelper;
 
 class FileGetContentsClientSpec extends ObjectBehavior
 {
+    function let(Request $request, FileGetContentsClientHelper $helper)
+    {
+        $request->beADoubleOf('\Superdesk\ContentApiSdk\API\Request');
+        $request->getOptions()->willReturn(array());
+        $helper->beADoubleOf('\Superdesk\ContentApiSdk\Client\FileGetContentsClientHelper');
+        $this->beConstructedWith($helper);
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType('Superdesk\ContentApiSdk\Client\FileGetContentsClient');
         $this->shouldImplement('Superdesk\ContentApiSdk\Client\ClientInterface');
     }
 
-    function let()
+    function it_should_make_a_call_to_a_remote_server($request, $helper)
     {
-        $config = array('base_uri' => 'http://httpbin.org');
-        $this->beConstructedWith($config);
-    }
-
-    function it_should_make_a_call_to_a_remote_server()
-    {
-        $this->makeApiCall('/status/200', null, null)->shouldBe('');
-    }
-
-    function it_should_throw_an_exception_when_an_error_occurs()
-    {
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ContentApiException')->duringMakeApiCall('/status/404', null, null);
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ContentApiException')->duringMakeApiCall('/status/500', null, null);
-    }
-
-    function it_should_throw_an_exception_on_invalid_baseuri()
-    {
-        $config = array('base_uri' => '');
-        $this->beConstructedWith($config);
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ContentApiException')->duringMakeApiCall('', null, null);
-    }
-
-    function it_should_be_able_to_return_a_response_as_a_string()
-    {
-        $config = array(
-            'base_uri' => 'http://httpbin.org',
-            'options' => array(
-                'http' => array(
-                    'header' => array(
-                        "Accept: application/json\r\n"
-                    )
-                )
-            )
+        $body = '{"_meta": {"max_results": 2, "total": 45, "page": 3}, "_links": {"self": {"title": "packages", "href": "packages?start_date=2015-01-01&max_results=2&page=3"}, "parent": {"title": "home", "href": "/"}, "next": {"title": "next page", "href": "packages?max_results=2&page=4"}, "prev": {"title": "previous page", "href": "packages?max_results=2&page=2"}, "last": {"title": "last page", "href": "packages?max_results=2&page=23"}}, "_items": [{"body_html": "<p>SAUDI-LED COALITION SPOKESMAN SAYS COALITION JETS WERE IN ACTION\nIN SAADA GOVERNORATE, BUT NOT INSIDE CITY</p>", "pubstatus": "usable", "subject": [{"qcode": "16009000", "name": "war"}, {"qcode": "11002000", "name": "diplomacy"}, {"qcode": "10000000", "name": "lifestyle and leisure"}, {"qcode": "11000000", "name": "politics"}, {"qcode": "16000000", "name": "unrest, conflicts and  war"}], "uri": "http://api.master.dev.superdesk.org/packages/urn%3Anewsml%3Alocalhost%3A2015-10-27T17%3A53%3A17.408024%3Aa53e9fb0-d43e-41a4-a767-0dddaa549842", "headline": "SAUDI-LED COALITION SPOKESMAN SAYS CO", "priority": 1, "associations": {"main": [{"uri": "http://api.master.dev.superdesk.org/items/tag%3Alocalhost%3A2015%3A120dfa7c-62eb-40c4-8972-7e0d41e3c220", "type": "text"}]}, "_type": "items", "version": 2, "_links": {"self": {"title": "Package", "href": "packages/urn:newsml:localhost:2015-10-27T17:53:17.408024:a53e9fb0-d43e-41a4-a767-0dddaa549842"}}, "urgency": 1, "language": "en", "versioncreated": "2015-10-27T17:53:17+0000", "byline": "mkk", "located": "Santa Fe", "type": "composite"}, {"body_html": "<p>NAREG DARWIN</p>", "pubstatus": "usable", "subject": [{"qcode": "01001000", "parent": "01000000", "name": "archaeology"}], "uri": "http://api.master.dev.superdesk.org/packages/urn%3Anewsml%3Alocalhost%3A2015-10-27T21%3A26%3A35.366266%3Acbdb917d-5e5e-4796-b384-c784baa766d2", "headline": "NAREG DARWIN", "priority": 1, "associations": {"main": [{"uri": "http://api.master.dev.superdesk.org/items/urn%3Anewsml%3Alocalhost%3A2015-10-27T21%3A26%3A07.748901%3A49745a57-04d8-4645-8e63-b3a06f2ca36b", "type": "text"}]}, "_type": "items", "version": 2, "_links": {"self": {"title": "Package", "href": "packages/urn:newsml:localhost:2015-10-27T21:26:35.366266:cbdb917d-5e5e-4796-b384-c784baa766d2"}}, "urgency": 1, "language": "en", "versioncreated": "2015-10-27T21:26:35+0000", "byline": "N", "located": "Holdfast Bay", "type": "composite"}]}';
+        $headers = array(
+            'Content-Type' => 'application/json',
         );
-        $this->beConstructedWith($config);
-        $this->makeApiCall('/headers', null, null, false)->shouldBeString();
+        $request->getFullUrl()->willReturn('http://httpbin.org/status/200');
+        $helper->sendRequest(Argument::type('string'), Argument::type('array'))->willReturn(array(
+            'headers' => $headers,
+            'body' => $body
+        ));
+
+        $this->makeApiCall($request)->shouldBeAnInstanceOf('\Superdesk\ContentApiSdk\API\Response');
     }
 
-    function it_should_be_able_to_return_a_response_as_valid_array_format()
+    function it_should_throw_an_exception_when_response_object_cannot_be_created(Request $request)
     {
-        $config = array(
-            'base_uri' => 'http://httpbin.org',
-            'options' => array(
-                'http' => array(
-                    'header' => array
-                    (
-                        "Accept: application/json\r\n"
-                    )
-                )
-            )
-        );
-        $this->beConstructedWith($config);
-        $response = $this->makeApiCall('/headers', null, null, true);
-        $response->shouldBeArray();
-        $response->shouldHaveKey('headers');
-        $response->shouldHaveKey('status');
-        $response->shouldHaveKey('reason');
-        $response->shouldHaveKey('version');
-        $response->shouldHaveKey('body');
+        $request->getFullUrl()->willReturn('http://httpbin.org/status/200');
+        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ClientException')->duringMakeApiCall($request);
+    }
 
-        $response['headers']->shouldBeArray();
-        $response['status']->shouldBeInteger();
-        $response['reason']->shouldBeString();
-        $response['version']->shouldBeString();
-        $response['body']->shouldBeString();
+    function it_should_throw_an_exception_on_error_http_status(Request $request)
+    {
+        $request->getFullUrl()->willReturn('http://httpbin.org/status/404');
+        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ClientException')->duringMakeApiCall($request);
+        $request->getFullUrl()->willReturn('http://httpbin.org/status/500');
+        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\ClientException')->duringMakeApiCall($request);
     }
 }

--- a/spec/Superdesk/ContentApiSdk/Client/FileGetContentsClientSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Client/FileGetContentsClientSpec.php
@@ -28,7 +28,7 @@ class FileGetContentsClientSpec extends ObjectBehavior
         $request->beADoubleOf('\Superdesk\ContentApiSdk\API\Request');
         $request->getOptions()->willReturn(array());
         $helper->beADoubleOf('\Superdesk\ContentApiSdk\Client\FileGetContentsClientHelper');
-        $this->beConstructedWith($helper);
+        $this->beConstructedWith($helper, array());
     }
 
     function it_is_initializable()

--- a/spec/Superdesk/ContentApiSdk/ContentApiSdkSpec.php
+++ b/spec/Superdesk/ContentApiSdk/ContentApiSdkSpec.php
@@ -18,6 +18,8 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Superdesk\ContentApiSdk\Client\ClientInterface;
 use Superdesk\ContentApiSdk\ContentApiSdk;
+use Superdesk\ContentApiSdk\API\Request;
+use Superdesk\ContentApiSdk\API\Response;
 
 class ContentApiSdkSpec extends ObjectBehavior
 {
@@ -26,107 +28,39 @@ class ContentApiSdkSpec extends ObjectBehavior
         $this->shouldHaveType('Superdesk\ContentApiSdk\ContentApiSdk');
     }
 
-    function let(ClientInterface $client)
+    function let(ClientInterface $client, Request $request, Response $response)
     {
-        $client->beADoubleOf('Superdesk\ContentApiSdk\Client\FileGetContentsClient');
         $this->beConstructedWith($client);
     }
 
-    function its_method_get_item_should_return_an_item($client)
+    function its_method_get_item_should_return_an_item(ClientInterface $client, Request $request)
     {
-        $client->makeApiCall(Argument::Any(), null, null)->willReturn('{ "version": "v3", "renditions": { "main": { "height": 720, "title": "Cat Full Resolution", "href": "http:/pictures.com/photos/cat-big.jpg", "width": 1050, "mimetype": "image/jpg" }, "small": { "height": 180, "title": "Cat Low Resolution", "href": "http:/pictures.com/photos/cat-small.jpg", "width": 262, "mimetype": "image/jpg" } }, "pubstatus": "usable", "urgency": 9, "type": "picture", "located": "Some backyard in one of the many Berlin houses", "description_html": "<p>This is a <em>cute</em> picture of our cat.</p>", "_links": { "parent": { "title": "home", "href": "/" }, "collection": { "title": "items", "href": "items" }, "self": { "title": "Item", "href": "items/tag:demodata.org,0001:ninjs_XYZ123" } }, "description_text": "This is a cute picture of our cat.", "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0001%3Aninjs_XYZ123", "place": [ { "name": "my neighbour\'s backyard" }, { "name": "Berlin" }, { "name": "Germany" } ], "headline": "Amazing! A very cute fluffy cat!", "versioncreated": "2015-03-16T08:12:00+0000", "byline": "Andy Catlover", "usageterms": "You can use this photo in any way you want." }');
-        $this->getItem(Argument::any())->shouldReturnAnInstanceOf('Superdesk\ContentApiSdk\Data\Item');
+        $request = $this->getNewRequest(sprintf('%s/%s', ContentApiSdk::SUPERDESK_ENDPOINT_ITEMS, Argument::type('string')));
+        $client->makeApiCall($request)->shouldBeCalled()->willReturn(new Response('{"pubstatus": "usable", "_links": {"parent": {"href": "/", "title": "home"}, "collection": {"href": "items", "title": "items"}, "self": {"href": "items/tag:example.com,0001:newsml_BRE9A607", "title": "Item"}}, "body_text": "Andromeda and Milky Way will collide in about 2 billion years", "type": "text", "language": "en", "versioncreated": "2015-03-09T16:32:23+0000", "uri": "http://api.master.dev.superdesk.org/items/tag%3Aexample.com%2C0001%3Anewsml_BRE9A607", "version": "2", "headline": "Andromeda on a collision course"}'));
+        $this->getItem(Argument::type('string'))->shouldReturnAnInstanceOf('Superdesk\ContentApiSdk\Data\Item');
     }
 
-    function its_method_get_item_should_return_an_exception_on_invalid_data($client)
-    {
-        $client->makeApiCall(Argument::Any(), null, null)->willReturn(null);
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetItem(Argument::any());
-
-        $client->makeApiCall(Argument::Any(), null, null)->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="no" ?><error>Invalid response</error>');
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetItem(Argument::any());
-    }
-
-    function its_method_get_items_should_return_null_for_no_items($client)
+    function its_method_get_items_should_return_a_resource_collection(ClientInterface $client, Request $request)
     {
         $parameters = array('start_date' => '1970-01-01');
-        $client->makeApiCall('/items', $parameters, null)->willReturn('{ "_links": { "parent": { "title": "home", "href": "/" }, "self": { "title": "items", "href": "items?start_date=2015-08-01" } }, "_items": [], "_meta": { "page": 1, "total": 0, "max_results": 25 } }');
-        $this->getItems($parameters)->shouldBe(null);
+        $request = $this->getNewRequest(ContentApiSdk::SUPERDESK_ENDPOINT_ITEMS, $parameters);
+        $client->makeApiCall($request)->willReturn('{ "_links": { "parent": { "title": "home", "href": "/" }, "self": { "title": "items", "href": "items?start_date=2015-08-01" } }, "_items": [], "_meta": { "page": 1, "total": 0, "max_results": 25 } }');
+        $this->getItems($parameters)->shouldReturnAnInstanceOf('Superdesk\ContentApiSdk\API\Pagerfanta\ResourceCollection');
     }
 
-    function its_method_get_items_should_return_items_for_items($client)
+    function its_method_get_package_should_return_a_package(ClientInterface $client, Request $request)
+    {
+        $request = $this->getNewRequest(sprintf('%s/%s', ContentApiSdk::SUPERDESK_ENDPOINT_PACKAGES, Argument::type('string')));
+        $client->makeApiCall($request)->shouldBeCalled()->willReturn(new Response('{"headline": "foo bar", "version": "1", "type": "composite", "versioncreated": "2015-02-10T06:49:47+0000", "_links": {"parent": {"title": "home", "href": "/"}, "collection": {"title": "packages", "href": "packages"}, "self": {"title": "Package", "href": "packages/tag:example.com,0001:newsml_BRE9A606"}}, "pubstatus": "usable", "language": "en", "uri": "http://api.master.dev.superdesk.org/packages/tag%3Aexample.com%2C0001%3Anewsml_BRE9A606"}'));
+        $this->getPackage(Argument::type('string'))->shouldReturnAnInstanceOf('Superdesk\ContentApiSdk\Data\Package');
+    }
+
+    function its_method_get_packges_should_return_a_resource_collection(ClientInterface $client, Request $request)
     {
         $parameters = array('start_date' => '1970-01-01');
-        $client->makeApiCall('/items', $parameters, null)->willReturn('{ "_links": { "parent": { "title": "home", "href": "/" }, "self": { "title": "items", "href": "items?start_date=2015-01-01" } }, "_items": [ { "version": "v3", "renditions": { "main": { "height": 720, "title": "Cat Full Resolution", "href": "http:/pictures.com/photos/cat-big.jpg", "width": 1050, "mimetype": "image/jpg" }, "small": { "height": 180, "title": "Cat Low Resolution", "href": "http:/pictures.com/photos/cat-small.jpg", "width": 262, "mimetype": "image/jpg" } }, "pubstatus": "usable", "urgency": 9, "type": "picture", "located": "Some backyard in one of the many Berlin houses", "description_html": "<p>This is a <em>cute</em> picture of our cat.</p>", "_links": { "self": { "title": "Item", "href": "items/tag:demodata.org,0001:ninjs_XYZ123" } }, "description_text": "This is a cute picture of our cat.", "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0001%3Aninjs_XYZ123", "place": [ { "name": "my neighbour\'s backyard" }, { "name": "Berlin" }, { "name": "Germany" } ], "headline": "Amazing! A very cute fluffy cat!", "versioncreated": "2015-03-16T08:12:00+0000", "byline": "Andy Catlover", "usageterms": "You can use this photo in any way you want." }, { "version": "v1", "person": [ { "name": "John McWriter", "rel": "author" } ], "_links": { "self": { "title": "Item", "href": "items/tag:demodata.org,0003:ninjs_XYZ123" } }, "body_text": "LONDON, UK (DD.org) -- Everybody happily celebrating.", "profile": "text-only", "copyrightnotice": "Copyright 2015 Santa & Friends - Free to use for children.", "pubstatus": "usable", "language": "en", "type": "text", "located": "London, UK, Europe", "subject": [ { "name": "London", "rel": "about" }, { "name": "Holidays", "rel": "about" }, { "name": "Entertainment", "rel": "about" } ], "urgency": 8, "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0003%3Aninjs_XYZ123", "headline": "People in London celebrate New Year", "versioncreated": "2015-01-01T00:00:01+0000", "body_html": "<p>LONDON, UK (DD.org) -- Everybody happily celebrating.</p>", "byline": "Santa Claus and John McWriter", "place": [ { "name": "London" }, { "name": "UK" }, { "name": "Europe" } ] }, { "version": "v2", "person": [ { "name": "John McWriter", "rel": "author" } ], "_links": { "self": { "title": "Item", "href": "items/tag:demodata.org,0004:ninjs_XYZ123" } }, "body_text": "LONDON, UK (DD.org) -- Everybody is celebrating.", "profile": "text-only", "copyrightnotice": "Copyright 2015 Santa & Friends - Free to use for children.", "pubstatus": "usable", "language": "en", "type": "text", "located": "London, UK, Europe", "subject": [ { "name": "London", "rel": "about" }, { "name": "Holidays", "rel": "about" }, { "name": "Entertainment", "rel": "about" } ], "urgency": 6, "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0004%3Aninjs_XYZ123", "headline": "People in UK celebrate New Year", "versioncreated": "2015-01-01T01:25:08+0000", "body_html": "<p>LONDON, UK (DD.org) -- Everybody is celebrating.</p>", "byline": "Santa Claus and John McWriter", "place": [ { "name": "London" }, { "name": "UK" }, { "name": "Europe" } ] }, { "version": "v1", "person": [ { "name": "Donald Banks", "rel": "author" } ], "_links": { "self": { "title": "Item", "href": "items/tag:demodata.org,0005:ninjs_XYZ123" } }, "body_text": "PARIS, FR -- At the press conference, there was...", "profile": "text-only", "copyrightnotice": "Copyright 2015 DemoData ltd., All Rights Reserved.", "pubstatus": "usable", "language": "en", "type": "text", "located": "Paris city center, France", "subject": [ { "name": "France", "rel": "about" }, { "name": "Politics", "rel": "about" }, { "name": "Daily news", "rel": "about" } ], "urgency": 5, "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0005%3Aninjs_XYZ123", "headline": "Hollande proposes a new law", "versioncreated": "2015-01-31T12:41:55+0000", "body_html": "<p>PARIS, FR -- At the press conference, there was...</p>", "byline": "Donald Banks", "place": [ { "name": "Paris" }, { "name": "France" } ] }, { "version": "v1", "person": [ { "name": "Mr. Ice", "rel": "author" } ], "_links": { "self": { "title": "Item", "href": "items/tag:demodata.org,0008:ninjs_XYZ123" } }, "body_text": "OSTRAVA, CZ -- The result was 5:1.", "profile": "text-only", "copyrightnotice": "Free for non-commercial use", "pubstatus": "usable", "language": "en", "type": "text", "located": "Ostrava Ice Hockey Hall", "subject": [ { "name": "Sports", "rel": "about" }, { "name": "Hockey", "rel": "about" } ], "urgency": 9, "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0008%3Aninjs_XYZ123", "headline": "USA beats the Finns", "versioncreated": "2015-05-02T17:12:39+0000", "body_html": "<p>OSTRAVA, CZ -- The result was 5:1.</p>", "byline": "Mr. Ice", "place": [ { "name": "Ostrava" }, { "name": "Czech Republic" } ] }, { "version": "v1", "person": [ { "name": "Peter Lamut", "rel": "author" } ], "_links": { "self": { "title": "Item", "href": "items/tag:demodata.org,0009:ninjs_XYZ123" } }, "description_html": "<p>The goal is to provide sample items &amp; packages for testing</p>", "description_text": "The goal is to provide sample items & packages for testing", "body_text": "This body text describes the whole thing.", "profile": "text-only", "copyrightnotice": "Ask Surcefabrcic z.ú. for permission", "pubstatus": "usable", "language": "en", "type": "text", "located": "Croatian coast", "subject": [ { "name": "Tourism", "rel": "about" } ], "urgency": 9, "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0009%3Aninjs_XYZ123", "headline": "API demo content under development", "versioncreated": "2015-05-20T22:19:10+0000", "body_html": "<p>This body text describes the whole thing.</p>", "byline": "Peter Lamut", "place": [ { "name": "Rijeka" }, { "name": "Croatia" } ] }, { "version": "v1", "_links": { "self": { "title": "Item", "href": "items/tag:demodata.org,0010:ninjs_XYZ123" } }, "description_text": "V gostilni pod Rožnikom so spekli okusne čevapčiče", "body_text": "Kosilo je bilo pripravljeno v 10-ih minutah in to je to.", "profile": "text-only", "language": "sl", "pubstatus": "usable", "person": [ { "name": "Peter Lamut", "rel": "author" } ], "type": "text", "located": "V glavnem mestu Slovenije", "subject": [ { "name": "Food", "rel": "about" }, { "name": "Foreign News", "rel": "about" } ], "urgency": 9, "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0010%3Aninjs_XYZ123", "headline": "Peter je šel na odlično kosilo", "versioncreated": "2015-03-21T12:05:49+0000", "body_html": "<p>Kosilo je bilo pripravljeno v 10-ih minutah in to je to.</p>", "byline": "avtor prispevka je Peter Lamut", "place": [ { "name": "Ljubljana" }, { "name": "Slovenija" } ] } ], "_meta": { "page": 1, "total": 7, "max_results": 25 }}');
-
-        $array = $this->getItems($parameters);
-        $array->shouldBeArray();
-        foreach ($array as $item) {
-            $item->shouldHaveType('Superdesk\ContentApiSdk\Data\Item');
-        }
-    }
-
-    function its_method_get_items_should_return_an_exception_for_invalid_data($client)
-    {
-        $parameters = array('start_date' => '1970-01-01');
-
-        $client->makeApiCall('/items', $parameters, null)->willReturn(null);
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetItems($parameters);
-
-        $client->makeApiCall('/items', $parameters, null)->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="no" ?><error>Invalid response</error>');
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetItems($parameters);
-
-        $client->makeApiCall('/items', $parameters, null)->willReturn('{ "_links": { "parent": { "title": "home", "href": "/" }, "self": { "title": "items", "href": "items?start_date=2015-08-01" } }, "_meta": { "page": 1, "total": 0, "max_results": 25 } }');
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetItems($parameters);
-    }
-
-    function its_method_get_package_should_return_a_package($client)
-    {
-        $client->makeApiCall(Argument::Any(), null, null)->willReturn('{ "version": "v1", "associations": { "mainpic": { "type": "picture", "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0001%3Aninjs_XYZ123" }, "storyText": { "type": "text", "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0003%3Aninjs_XYZ123" } }, "person": [ { "name": "Hulk Hogan", "rel": "author" }, { "name": "The Phototaker", "rel": "photographer" } ], "_links": { "parent": { "title": "home", "href": "/" }, "collection": { "title": "packages", "href": "packages" }, "self": { "title": "Package", "href": "packages/tag:demodata.org,0012:ninjs_XYZ123" } }, "body_text": "Want to try McRide or McGhostHouse?", "profile": "text-photo", "copyrightnotice": "Free to use for everyone", "pubstatus": "usable", "language": "en", "type": "composite", "located": "Bilbao city center, Spain", "subject": [ { "name": "Business", "rel": "about" }, { "name": "Economy", "rel": "about" }, { "name": "Entertainment", "rel": "about" } ], "urgency": 8, "uri": "http://publicapi:5050/packages/tag%3Ademodata.org%2C0012%3Aninjs_XYZ123", "headline": "McDonalds opens its own theme park", "versioncreated": "2014-08-15T11:33:42+0000", "body_html": "<p>Want to try <em>McRide</em> or <em>McGhostHouse</em>?</p>", "byline": "Hulk Hogan, The Undertaker", "place": [ { "name": "Bilbao" }, { "name": "Spain" } ] }');
-        $this->getPackage(Argument::any())->shouldReturnAnInstanceOf('Superdesk\ContentApiSdk\Data\Package');
-    }
-
-    function its_method_get_package_should_return_an_exception_on_invalid_data($client)
-    {
-        $client->makeApiCall(Argument::Any(), null, null)->willReturn(null);
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetPackage(Argument::any());
-
-        $client->makeApiCall(Argument::Any(), null, null)->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="no" ?><error>Invalid response</error>');
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetPackage(Argument::any());
-    }
-
-    function its_method_get_packages_should_return_null_for_no_packages($client)
-    {
-        $parameters = array('start_date' => '1970-01-01');
-        $client->makeApiCall('/packages', $parameters, null)->willReturn('{ "_links": { "parent": { "title": "home", "href": "/" }, "self": { "title": "packages", "href": "packages?start_date=2015-08-10" } }, "_items": [], "_meta": { "page": 1, "total": 0, "max_results": 25 } }');
-
-        $this->getPackages($parameters)->shouldBe(null);
-    }
-
-    function its_method_get_packages_should_return_packges_for_packages($client)
-    {
-        $parameters = array('start_date' => '1970-01-01');
-        $client->makeApiCall('/packages', $parameters, null)->willReturn('{ "_links": { "parent": { "title": "home", "href": "/" }, "self": { "title": "packages", "href": "packages?start_date=1970-01-01" } }, "_items": [ { "version": "v1", "associations": { "videoFootage": { "type": "video", "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0002%3Aninjs_XYZ123" }, "relatedStory": { "type": "composite", "uri": "http://publicapi:5050/packages/tag%3Ademodata.org%2C0012%3Aninjs_XYZ123" } }, "person": [ { "name": "Vito Corleone", "rel": "about" }, { "name": "Franco di Banco", "rel": "author" }, { "name": "Photo Grapher jr.", "rel": "photographer" } ], "_links": { "self": { "title": "Package", "href": "packages/tag:demodata.org,0011:ninjs_XYZ123" } }, "body_text": "Reporter: \"Don Vito Corleone, bongiorno!\", etc.", "profile": "rich-interlinked-story", "copyrightnotice": "Licensed under MIT public license", "pubstatus": "usable", "language": "en", "type": "composite", "located": "Naples, Italy", "subject": [ { "name": "Celebrities", "rel": "about" }, { "name": "Interviews", "rel": "about" } ], "urgency": 4, "uri": "http://publicapi:5050/packages/tag%3Ademodata.org%2C0011%3Aninjs_XYZ123", "headline": "Exclusive interview with the great mafia boss", "versioncreated": "2015-05-03T07:48:51+0000", "body_html": "<b>Reporter:</b> &quot;Don Vito Corleone, bongiorno!&quot;, etc.", "byline": "Franco di Banco, Photo Grapher jr. and an anonymous mafia source", "place": [ { "name": "Naples" }, { "name": "Italy" } ] }, { "version": "v1", "associations": { "mainpic": { "type": "picture", "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0001%3Aninjs_XYZ123" }, "storyText": { "type": "text", "uri": "http://publicapi:5050/items/tag%3Ademodata.org%2C0003%3Aninjs_XYZ123" } }, "person": [ { "name": "Hulk Hogan", "rel": "author" }, { "name": "The Phototaker", "rel": "photographer" } ], "_links": { "self": { "title": "Package", "href": "packages/tag:demodata.org,0012:ninjs_XYZ123" } }, "body_text": "Want to try McRide or McGhostHouse?", "profile": "text-photo", "copyrightnotice": "Free to use for everyone", "pubstatus": "usable", "language": "en", "type": "composite", "located": "Bilbao city center, Spain", "subject": [ { "name": "Business", "rel": "about" }, { "name": "Economy", "rel": "about" }, { "name": "Entertainment", "rel": "about" } ], "urgency": 8, "uri": "http://publicapi:5050/packages/tag%3Ademodata.org%2C0012%3Aninjs_XYZ123", "headline": "McDonalds opens its own theme park", "versioncreated": "2014-08-15T11:33:42+0000", "body_html": "<p>Want to try <em>McRide</em> or <em>McGhostHouse</em>?</p>", "byline": "Hulk Hogan, The Undertaker", "place": [ { "name": "Bilbao" }, { "name": "Spain" } ] } ], "_meta": { "page": 1, "total": 2, "max_results": 25 } }');
-
-        $array = $this->getPackages($parameters);
-        $array->shouldBeArray();
-        foreach ($array as $package) {
-            $package->shouldHaveType('Superdesk\ContentApiSdk\Data\Package');
-        }
-    }
-
-    function its_method_get_packages_should_return_an_exception_for_invalid_data($client)
-    {
-        $parameters = array('start_date' => '1970-01-01');
-
-        $client->makeApiCall('/packages', $parameters, null)->willReturn(null);
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetPackages($parameters);
-
-        $client->makeApiCall('/packages', $parameters, null)->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="no" ?><error>Invalid response</error>');
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetPackages($parameters);
-
-        $client->makeApiCall('/packages', $parameters, null)->willReturn('{ "_links": { "parent": { "title": "home", "href": "/i" }, "self": { "title": "packages", "href": "packages?start_date=2015-08-10" } }, "_meta": { "page": 1, "total": 0, "max_results": 25 } }');
-        $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetPackages($parameters);
+        $request = $this->getNewRequest(ContentApiSdk::SUPERDESK_ENDPOINT_PACKAGES, $parameters);
+        $client->makeApiCall($request)->willReturn('{ "_links": { "parent": { "title": "home", "href": "/" }, "self": { "title": "items", "href": "items?start_date=2015-08-01" } }, "_items": [], "_meta": { "page": 1, "total": 0, "max_results": 25 } }');
+        $this->getItems($parameters)->shouldReturnAnInstanceOf('Superdesk\ContentApiSdk\API\Pagerfanta\ResourceCollection');
     }
 
     function its_method_get_available_endpoints_should_contain_all_endpoints()
@@ -272,7 +206,6 @@ class ContentApiSdkSpec extends ObjectBehavior
     {
         $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetValidJsonObj(null);
         $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetValidJsonObj('<?xml version="1.0" encoding="UTF-8" standalone="no" ?><error>This is not json</error>');
-
         $this->shouldThrow('\Superdesk\ContentApiSdk\Exception\InvalidDataException')->duringGetValidJsonObj('{ "some key" : "some value }');
     }
 }

--- a/spec/Superdesk/ContentApiSdk/ContentApiSdkSpec.php
+++ b/spec/Superdesk/ContentApiSdk/ContentApiSdkSpec.php
@@ -60,7 +60,7 @@ class ContentApiSdkSpec extends ObjectBehavior
         $parameters = array('start_date' => '1970-01-01');
         $request = $this->getNewRequest(ContentApiSdk::SUPERDESK_ENDPOINT_PACKAGES, $parameters);
         $client->makeApiCall($request)->willReturn('{ "_links": { "parent": { "title": "home", "href": "/" }, "self": { "title": "items", "href": "items?start_date=2015-08-01" } }, "_items": [], "_meta": { "page": 1, "total": 0, "max_results": 25 } }');
-        $this->getItems($parameters)->shouldReturnAnInstanceOf('Superdesk\ContentApiSdk\API\Pagerfanta\ResourceCollection');
+        $this->getPackages($parameters)->shouldReturnAnInstanceOf('Superdesk\ContentApiSdk\API\Pagerfanta\ResourceCollection');
     }
 
     function its_method_get_available_endpoints_should_contain_all_endpoints()

--- a/spec/Superdesk/ContentApiSdk/Data/ItemSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Data/ItemSpec.php
@@ -15,6 +15,7 @@
 namespace spec\Superdesk\ContentApiSdk\Data;
 
 use PhpSpec\ObjectBehavior;
+use Superdesk\ContentApiSdk\API\Response;
 
 class ItemSpec extends ObjectBehavior
 {
@@ -29,5 +30,25 @@ class ItemSpec extends ObjectBehavior
         $validId = 'tag:demodata.org,0012:ninjs_XYZ123';
 
         $this->getId()->shouldBe($validId);
+    }
+
+    function it_should_convert_a_response_properly()
+    {
+        $response = new Response('{"pubstatus": "usable", "_links": {"parent": {"href": "/", "title": "home"}, "collection": {"href": "items", "title": "items"}, "self": {"href": "items/tag:example.com,0001:newsml_BRE9A607", "title": "Item"}}, "body_text": "Andromeda and Milky Way will collide in about 2 billion years", "type": "text", "language": "en", "versioncreated": "2015-03-09T16:32:23+0000", "uri": "http://api.master.dev.superdesk.org/items/tag%3Aexample.com%2C0001%3Anewsml_BRE9A607", "version": "2", "headline": "Andromeda on a collision course"}');
+
+        $this->beConstructedWith($response->getResources());
+
+        foreach ($response->getResources() as $property => $value) {
+            $this->shouldHaveProperty($property);
+        }
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'haveProperty' => function ($object, $property) {
+                return property_exists($object, $property);
+            }
+        ];
     }
 }

--- a/spec/Superdesk/ContentApiSdk/Data/ItemSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Data/ItemSpec.php
@@ -45,10 +45,10 @@ class ItemSpec extends ObjectBehavior
 
     public function getMatchers()
     {
-        return [
+        return array(
             'haveProperty' => function ($object, $property) {
                 return property_exists($object, $property);
             }
-        ];
+        );
     }
 }

--- a/spec/Superdesk/ContentApiSdk/Data/PackageSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Data/PackageSpec.php
@@ -15,6 +15,7 @@
 namespace spec\Superdesk\ContentApiSdk\Data;
 
 use PhpSpec\ObjectBehavior;
+use Superdesk\ContentApiSdk\API\Response;
 
 class PackageSpec extends ObjectBehavior
 {
@@ -29,5 +30,25 @@ class PackageSpec extends ObjectBehavior
         $validId = 'tag:demodata.org,0003:ninjs_XYZ123';
 
         $this->getId()->shouldBe($validId);
+    }
+
+    function it_should_convert_a_response_properly()
+    {
+        $response = new Response('{"headline": "foo bar", "version": "1", "type": "composite", "versioncreated": "2015-02-10T06:49:47+0000", "_links": {"parent": {"title": "home", "href": "/"}, "collection": {"title": "packages", "href": "packages"}, "self": {"title": "Package", "href": "packages/tag:example.com,0001:newsml_BRE9A606"}}, "pubstatus": "usable", "language": "en", "uri": "http://api.master.dev.superdesk.org/packages/tag%3Aexample.com%2C0001%3Anewsml_BRE9A606"}');
+
+        $this->beConstructedWith($response->getResources());
+
+        foreach ($response->getResources() as $property => $value) {
+            $this->shouldHaveProperty($property);
+        }
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'haveProperty' => function ($object, $property) {
+                return property_exists($object, $property);
+            }
+        ];
     }
 }

--- a/spec/Superdesk/ContentApiSdk/Data/PackageSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Data/PackageSpec.php
@@ -45,10 +45,10 @@ class PackageSpec extends ObjectBehavior
 
     public function getMatchers()
     {
-        return [
+        return array(
             'haveProperty' => function ($object, $property) {
                 return property_exists($object, $property);
             }
-        ];
+        );
     }
 }

--- a/spec/Superdesk/ContentApiSdk/Exception/ClientExceptionSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Exception/ClientExceptionSpec.php
@@ -16,10 +16,10 @@ namespace spec\Superdesk\ContentApiSdk\Exception;
 
 use PhpSpec\ObjectBehavior;
 
-class ContentApiExceptionSpec extends ObjectBehavior
+class ClientExceptionSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Superdesk\ContentApiSdk\Exception\ContentApiException');
+        $this->shouldHaveType('Superdesk\ContentApiSdk\Exception\ClientException');
     }
 }

--- a/spec/Superdesk/ContentApiSdk/Exception/InvalidArgumentExceptionSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Exception/InvalidArgumentExceptionSpec.php
@@ -16,10 +16,10 @@ namespace spec\Superdesk\ContentApiSdk\Exception;
 
 use PhpSpec\ObjectBehavior;
 
-class ContentApiExceptionSpec extends ObjectBehavior
+class InvalidArgumentExceptionSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Superdesk\ContentApiSdk\Exception\ContentApiException');
+        $this->shouldHaveType('Superdesk\ContentApiSdk\Exception\InvalidArgumentException');
     }
 }

--- a/spec/Superdesk/ContentApiSdk/Exception/InvalidDataExceptionSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Exception/InvalidDataExceptionSpec.php
@@ -16,10 +16,10 @@ namespace spec\Superdesk\ContentApiSdk\Exception;
 
 use PhpSpec\ObjectBehavior;
 
-class ContentApiExceptionSpec extends ObjectBehavior
+class InvalidDataExceptionSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Superdesk\ContentApiSdk\Exception\ContentApiException');
+        $this->shouldHaveType('Superdesk\ContentApiSdk\Exception\InvalidDataException');
     }
 }

--- a/spec/Superdesk/ContentApiSdk/Exception/RequestExceptionSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Exception/RequestExceptionSpec.php
@@ -16,10 +16,10 @@ namespace spec\Superdesk\ContentApiSdk\Exception;
 
 use PhpSpec\ObjectBehavior;
 
-class ContentApiExceptionSpec extends ObjectBehavior
+class RequestExceptionSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Superdesk\ContentApiSdk\Exception\ContentApiException');
+        $this->shouldHaveType('Superdesk\ContentApiSdk\Exception\RequestException');
     }
 }

--- a/spec/Superdesk/ContentApiSdk/Exception/ResponseExceptionSpec.php
+++ b/spec/Superdesk/ContentApiSdk/Exception/ResponseExceptionSpec.php
@@ -16,10 +16,10 @@ namespace spec\Superdesk\ContentApiSdk\Exception;
 
 use PhpSpec\ObjectBehavior;
 
-class ContentApiExceptionSpec extends ObjectBehavior
+class ResponseExceptionSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Superdesk\ContentApiSdk\Exception\ContentApiException');
+        $this->shouldHaveType('Superdesk\ContentApiSdk\Exception\ResponseException');
     }
 }

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/ItemAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/ItemAdapter.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace Superdesk\ContentApiSdk\API\Pagerfanta;
+
+use Superdesk\ContentApiSdk\Data\Item;
+use Superdesk\ContentApiSdk\Exception\InvalidDataException;
+
+/**
+ * Adapter for items
+ */
+class ItemAdapter extends ResourceAdapter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getSlice($offset, $length)
+    {
+        $items = array();
+        $resources = parent::getSlice($offset, $length);
+
+        try {
+            foreach ($resources as $itemData) {
+                $items[] = new Item($itemData);
+            }
+        } catch(\Exception $e) {
+            throw new InvalidDataException('Could not convert resources to items.', $e->getCode(), $e);
+        }
+
+        return $items;
+    }
+}

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/ItemAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/ItemAdapter.php
@@ -16,6 +16,7 @@ namespace Superdesk\ContentApiSdk\API\Pagerfanta;
 
 use Superdesk\ContentApiSdk\Data\Item;
 use Superdesk\ContentApiSdk\Exception\InvalidDataException;
+use Exception;
 
 /**
  * Adapter for items
@@ -34,7 +35,7 @@ class ItemAdapter extends ResourceAdapter
             foreach ($resources as $itemData) {
                 $items[] = new Item($itemData);
             }
-        } catch(\Exception $e) {
+        } catch (Exception $e) {
             throw new InvalidDataException('Could not convert resources to items.', $e->getCode(), $e);
         }
 

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapter.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace Superdesk\ContentApiSdk\API\Pagerfanta;
+
+use Superdesk\ContentApiSdk\Data\Package;
+use Superdesk\ContentApiSdk\Exception\InvalidDataException;
+
+/**
+ * Adapter for package
+ */
+class PackageAdapter extends ResourceAdapter
+{
+    /**
+     * SDK Instance.
+     *
+     * @var Superdesk\CotentApiSdk\CotentApiSdk
+     */
+    protected $apiInstance;
+
+    /**
+     * Instantiate object.
+     *
+     * @param Superdesk\CotentApiSdk\Client\ClientInterface $client HTTP client
+     * @param Superdesk\CotentApiSdk\API\Request $request API Request is_object(var)
+     * @param Superdesk\CotentApiSdk\ContentApiSdk $apiInstance SDK Instance
+     * @param boolean $resolveAssociations Resolve package associations
+     */
+    public function __construct($client, $request, $apiInstance, $resolveAssociations)
+    {
+        parent::__construct($client, $request);
+
+        $this->apiInstance = $apiInstance;
+        $this->resolveAssociations = $resolveAssociations;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSlice($offset, $length)
+    {
+        $packages = array();
+        $resources = parent::getSlice($offset, $length);
+
+        try {
+            foreach ($resources as $itemData) {
+                $packages[] = new Package($itemData);
+            }
+
+            if ($this->resolveAssociations) {
+                foreach ($packages as $id => $package) {
+                    $associations = $this->apiInstance->getAssociationsFromPackage($package);
+                    $packages[$id] = $this->apiInstance->injectAssociations($package, $associations);
+                }
+            }
+        } catch(\Exception $e) {
+            throw new InvalidDataException('Could not convert resources to packages.', $e->getCode(), $e);
+        }
+
+        return $packages;
+    }
+}

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapter.php
@@ -29,7 +29,7 @@ class PackageAdapter extends ResourceAdapter
     /**
      * SDK Instance.
      *
-     * @var Superdesk\CotentApiSdk\CotentApiSdk
+     * @var ContentApiSdk
      */
     protected $apiInstance;
 

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapter.php
@@ -14,6 +14,9 @@
 
 namespace Superdesk\ContentApiSdk\API\Pagerfanta;
 
+use Superdesk\ContentApiSdk\API\Request;
+use Superdesk\ContentApiSdk\Client\ClientInterface;
+use Superdesk\ContentApiSdk\ContentApiSdk;
 use Superdesk\ContentApiSdk\Data\Package;
 use Superdesk\ContentApiSdk\Exception\InvalidDataException;
 use Exception;
@@ -33,13 +36,17 @@ class PackageAdapter extends ResourceAdapter
     /**
      * Instantiate object.
      *
-     * @param Superdesk\CotentApiSdk\Client\ClientInterface $client HTTP client
-     * @param Superdesk\CotentApiSdk\API\Request $request API Request is_object(var)
-     * @param Superdesk\CotentApiSdk\ContentApiSdk $apiInstance SDK Instance
+     * @param ClientInterface $client HTTP client
+     * @param Request $request API Request is_object(var)
+     * @param ContentApiSdk $apiInstance SDK Instance
      * @param boolean $resolveAssociations Resolve package associations
      */
-    public function __construct($client, $request, $apiInstance, $resolveAssociations)
-    {
+    public function __construct(
+        ClientInterface $client,
+        Request $request,
+        ContentApiSdk $apiInstance,
+        $resolveAssociations
+    ) {
         parent::__construct($client, $request);
 
         $this->apiInstance = $apiInstance;

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapter.php
@@ -16,6 +16,7 @@ namespace Superdesk\ContentApiSdk\API\Pagerfanta;
 
 use Superdesk\ContentApiSdk\Data\Package;
 use Superdesk\ContentApiSdk\Exception\InvalidDataException;
+use Exception;
 
 /**
  * Adapter for package
@@ -64,7 +65,7 @@ class PackageAdapter extends ResourceAdapter
                     $packages[$id] = $this->apiInstance->injectAssociations($package, $associations);
                 }
             }
-        } catch(\Exception $e) {
+        } catch (Exception $e) {
             throw new InvalidDataException('Could not convert resources to packages.', $e->getCode(), $e);
         }
 

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/PackageAdapter.php
@@ -34,6 +34,13 @@ class PackageAdapter extends ResourceAdapter
     protected $apiInstance;
 
     /**
+     * Resolve package associations.
+     *
+     * @var boolean
+     */
+    protected $resolveAssociations;
+
+    /**
      * Instantiate object.
      *
      * @param ClientInterface $client HTTP client

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapter.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace Superdesk\ContentApiSdk\API\Pagerfanta;
+
+use Pagerfanta\Adapter\AdapterInterface;
+
+/**
+ * Base adapter for api resources.
+ */
+class ResourceAdapter implements AdapterInterface
+{
+    /**
+     * HTTP Client.
+     *
+     * @var Superdesk\CotentApiSdk\Client\ClientInterface
+     */
+    protected $client;
+
+    /**
+     * API Request object.
+     *
+     * @var Superdesk\CotentApiSdk\API\Request
+     */
+    protected $request;
+
+    /**
+     * Instantiate object.
+     *
+     * @param Superdesk\CotentApiSdk\Client\ClientInterface $client HTTP Client
+     * @param Superdesk\CotentApiSdk\API\Request $request API Request object
+     */
+    public function __construct($client, $request)
+    {
+        $this->client = $client;
+        $this->request = $request;
+    }
+
+    /**
+     * Make call HTTP call.
+     *
+     * @return Superdesk\ContentApiSdk\API\Response API Response object
+     */
+    private function doCall()
+    {
+        return $this->client->makeApiCall($this->request);
+    }
+
+    /**
+     * Returns the number of results.
+     *
+     * @return integer The number of results.
+     */
+    public function getNbResults()
+    {
+        $response = $this->doCall();
+
+        return $this->response->getTotalResults();
+    }
+
+    /**
+     * Returns an slice of the results.
+     *
+     * @param integer $offset The offset.
+     * @param integer $length The length.
+     *
+     * @return array|\Traversable The slice.
+     */
+    public function getSlice($offset, $length)
+    {
+        $this->request->setOffsetAndLength($offset, $length);
+
+        $response = $this->doCall();
+
+        return $response->getResources();
+    }
+}

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapter.php
@@ -76,6 +76,8 @@ class ResourceAdapter implements AdapterInterface
      * @param integer $length The length.
      *
      * @return array|\Traversable The slice.
+     *
+     * @throws InvalidDataException
      */
     public function getSlice($offset, $length)
     {

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapter.php
@@ -15,6 +15,8 @@
 namespace Superdesk\ContentApiSdk\API\Pagerfanta;
 
 use Pagerfanta\Adapter\AdapterInterface;
+use Superdesk\ContentApiSdk\API\Request;
+use Superdesk\ContentApiSdk\Client\ClientInterface;
 
 /**
  * Base adapter for api resources.
@@ -24,24 +26,24 @@ class ResourceAdapter implements AdapterInterface
     /**
      * HTTP Client.
      *
-     * @var Superdesk\CotentApiSdk\Client\ClientInterface
+     * @var ClientInterface
      */
     protected $client;
 
     /**
      * API Request object.
      *
-     * @var Superdesk\CotentApiSdk\API\Request
+     * @var Request
      */
     protected $request;
 
     /**
      * Instantiate object.
      *
-     * @param Superdesk\CotentApiSdk\Client\ClientInterface $client HTTP Client
-     * @param Superdesk\CotentApiSdk\API\Request $request API Request object
+     * @param ClientInterface $client HTTP Client
+     * @param Request $request API Request object
      */
-    public function __construct($client, $request)
+    public function __construct(ClientInterface $client, Request $request)
     {
         $this->client = $client;
         $this->request = $request;
@@ -50,7 +52,7 @@ class ResourceAdapter implements AdapterInterface
     /**
      * Make call HTTP call.
      *
-     * @return Superdesk\ContentApiSdk\API\Response API Response object
+     * @return \Superdesk\ContentApiSdk\API\Response API Response object
      */
     private function doCall()
     {

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapter.php
@@ -77,7 +77,7 @@ class ResourceAdapter implements AdapterInterface
      * @param integer $offset The offset.
      * @param integer $length The length.
      *
-     * @return array|\Traversable The slice.
+     * @return array|stdClass|\Traversable The slice.
      *
      * @throws InvalidDataException
      */

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapter.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceAdapter.php
@@ -68,7 +68,7 @@ class ResourceAdapter implements AdapterInterface
     {
         $response = $this->doCall();
 
-        return $this->response->getTotalResults();
+        return $response->getTotalResults();
     }
 
     /**

--- a/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceCollection.php
+++ b/src/Superdesk/ContentApiSdk/API/Pagerfanta/ResourceCollection.php
@@ -12,22 +12,13 @@
  * @license http://www.superdesk.org/license
  */
 
-namespace Superdesk\ContentApiSdk\Client;
+namespace Superdesk\ContentApiSdk\API\Pagerfanta;
 
-use Superdesk\ContentApiSdk\API\Request;
-use Superdesk\ContentApiSdk\API\Response;
+use Pagerfanta\Pagerfanta;
 
 /**
- * Interface for clients.
+ * Resource collection wrapper for Pagerfanta.
  */
-interface ClientInterface
+class ResourceCollection extends Pagerfanta
 {
-    /**
-     * Makes a call to the public api and returns a response.
-     *
-     * @param  Request $request
-     *
-     * @return Response
-     */
-    public function makeApiCall(Request $request);
 }

--- a/src/Superdesk/ContentApiSdk/API/Request.php
+++ b/src/Superdesk/ContentApiSdk/API/Request.php
@@ -1,0 +1,311 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace Superdesk\ContentApiSdk\API;
+
+use Superdesk\ContentApiSdk\ContentApiSdk;
+use Superdesk\ContentApiSdk\Exception\ResponseException;
+use Superdesk\ContentApiSdk\Exception\RequestException;
+use Superdesk\ContentApiSdk\Exception\InvalidArgumentException;
+use Superdesk\ContentApiSdk\Exception\InvalidDataException;
+
+/**
+ * API Request object.
+ */
+class Request
+{
+    /**
+     * Protocol for api request.
+     *
+     * @var string
+     */
+    protected $protocol = 'https';
+
+    /**
+     * Hostname for api request.
+     *
+     * @var string
+     */
+    protected $host;
+
+    /**
+     * Api port.
+     *
+     * @var int
+     */
+    protected $port = 80;
+
+    /**
+     * Request uri.
+     *
+     * @var string
+     */
+    protected $uri;
+
+    /**
+     * Parameters for request.
+     *
+     * @var mixed[]
+     */
+    protected $parameters;
+
+    /**
+     * Validate parameters, unset invalid ones.
+     *
+     * @var boolean
+     */
+    protected $parameterValidation = true;
+
+    /**
+     * Request headers.
+     *
+     * @var string[]
+     */
+    protected $headers = array();
+
+    /**
+     * Request options, usuably in clients, etc.
+     *
+     * @var mixed[]
+     */
+    protected $options = array();
+
+    /**
+     * Construct a request object.
+     *
+     * @param string $hostname Host name
+     * @param string $uri Request uri
+     * @param mixed[] $parameters Parameters
+     * @param int $port Port
+     */
+    public function __construct($hostname = null, $uri = null, array $parameters = array(), $port = null)
+    {
+        if (is_string($hostname) && !empty($hostname)) {
+            $this->setHost($hostname);
+        }
+        if (is_string($uri) && !empty($uri)) {
+            $this->setUri($uri);
+        }
+        if (!empty($parameters)) {
+            $this->setParameters($parameters);
+        }
+        if (is_int($port)) {
+            $this->setPort($port);
+        }
+    }
+
+    /**
+     * Get base url.
+     *
+     * @return string
+     */
+    public function getBaseUrl()
+    {
+        return sprintf('%s://%s:%s/%s', $this->protocol, $this->host, $this->port, ContentApiSdk::getVersionURL());
+    }
+
+    /**
+     * Get full url.
+     *
+     * @return string
+     */
+    public function getFullUrl()
+    {
+        return sprintf('%s/%s?%s', $this->getBaseUrl(), trim($this->uri, '/ '), http_build_query($this->parameters));
+    }
+
+    /**
+     * Set hostname.
+     *
+     * @param string $host
+     *
+     * @return self
+     */
+    public function setHost($host)
+    {
+        $this->host = $host;
+
+        return $this;
+    }
+
+    /**
+     * Get host.
+     *
+     * @return string
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * Set port.
+     *
+     * @param int $port
+     *
+     * @return self
+     */
+    public function setPort($port)
+    {
+        $this->port = $port;
+
+        return $this;
+    }
+
+    /**
+     * Get port.
+     *
+     * @return int
+     */
+    public function getPort()
+    {
+        return $this->port;
+    }
+
+    /**
+     * Set uri.
+     *
+     * @param string $uri
+     *
+     * @return self
+     */
+    public function setUri($uri)
+    {
+        $this->uri = $uri;
+
+        return $this;
+    }
+
+    /**
+     * Get uri.
+     *
+     * @return string
+     */
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    /**
+     * Set query parameters.
+     *
+     * @param string[] $parameters
+     *
+     * @return self
+     *
+     * @throws RequestException If parameters data types are invalid
+     */
+    public function setParameters(array $parameters)
+    {
+        try {
+            $this->parameters = ContentApiSdk::processParameters($parameters, $this->parameterValidation);
+        } catch (InvalidArgumentException $e) {
+            throw new RequestException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get query parameters.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * Enables parameter validation
+     *
+     * @return self
+     */
+    public function enableParameterValidation()
+    {
+        $this->parameterValidation = true;
+
+        return $this;
+    }
+
+    /**
+     * Disables parameter validation
+     *
+     * @return self
+     */
+    public function disableParameterValidation()
+    {
+        $this->parameterValidation = false;
+    }
+
+    /**
+     * Gets the value of headers.
+     *
+     * @return string[]
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Sets the value of headers.
+     *
+     * @param string[] $headers Value to set
+     *
+     * @return self
+     */
+    public function setHeaders(array $headers)
+    {
+        $this->headers = $headers;
+
+        return $this;
+    }
+
+    /**
+     * Gets the value of options.
+     *
+     * @return mixed[]
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Sets the value of options.
+     *
+     * @param mixed[] $options Value to set
+     *
+     * @return self
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * Sets page number and max results per page parameters.
+     *
+     * @param int $offset Offset of rows
+     * @param int $length Length of rows
+     */
+    public function setOffsetAndLength($offset, $length)
+    {
+        $this->parameters['page'] = ceil($offset / $length);
+        $this->parameters['max_results'] = $length;
+    }
+}

--- a/src/Superdesk/ContentApiSdk/API/Response.php
+++ b/src/Superdesk/ContentApiSdk/API/Response.php
@@ -1,0 +1,375 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace Superdesk\ContentApiSdk\API;
+
+use Superdesk\ContentApiSdk\ContentApiSdk;
+use Superdesk\ContentApiSdk\Exception\ResponseException;
+use Superdesk\ContentApiSdk\Exception\InvalidDataException;
+use stdClass;
+
+/**
+ * API Response object.
+ */
+class Response
+{
+    const TYPE_ITEMS = 'items';
+    const TYPE_PACKAGES = 'packages';
+
+    const CONTENT_TYPE_JSON = 'application/json';
+    const CONTENT_TYPE_XML = 'application/xml';
+
+    /**
+     * Unprocessed body as returned by the api.
+     *
+     * @var string
+     */
+    protected $rawBody;
+
+    /**
+     * Content type of the response, we should support xml and json.
+     *
+     * @var string
+     */
+    protected $contentType;
+
+    /**
+     * Type of response.
+     *
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * Request URI.
+     *
+     * @var string
+     */
+    protected $href;
+
+    /**
+     * List of response headers.
+     *
+     * @var array
+     */
+    protected $headers;
+
+    /**
+     * Current page.
+     *
+     * @var int
+     */
+    protected $page;
+
+    /**
+     * Next page.
+     *
+     * @var int
+     */
+    protected $nextPage;
+
+    /**
+     * Previous page.
+     *
+     * @var int
+     */
+    protected $prevPage;
+
+    /**
+     * Last page.
+     *
+     * @var int
+     */
+    protected $lastPage;
+
+    /**
+     * Maximum of results on 1 page.
+     *
+     * @var int
+     */
+    protected $maxResults;
+
+    /**
+     * Total amount of results for current parameters.
+     *
+     * @var int
+     */
+    protected $total;
+
+    /**
+     * Array of resources.
+     *
+     * @var array
+     */
+    protected $resources;
+
+    /**
+     * Array of keys which are not part of the actual single data (item or
+     * package).
+     *
+     * @var array
+     */
+    protected $metaKeys = array(
+        '_links'
+    );
+
+    /**
+     * Constructs Response.
+     *
+     * @param string     $body    Body of a response as string
+     * @param array|null $headers List of headers
+     */
+    public function __construct($body, array $headers = null)
+    {
+        $this->rawBody = $body;
+        $this->headers = $headers;
+
+        $this->determineContentType();
+        $this->processRawBody();
+    }
+
+    /**
+     * Determine the content type of the response via header. If header is not
+     * set, then content will be analyzed. Throws exception on failure.
+     *
+     * @return string Content type of the response
+     *
+     * @throws ResponseException
+     */
+    private function determineContentType()
+    {
+        if (isset($this->headers['Content-Type']) && in_array($this->headers['Content-Type'], $this->getSupportedContenTypes())) {
+            $this->contentType = $this->headers['Content-Type'];
+
+            return;
+        }
+
+        // Try to determine content type based on body
+        try {
+            $xml = new \SimpleXMLElement($this->rawBody);
+            $this->contentType = self::CONTENT_TYPE_XML;
+
+            return;
+        } catch (\Exception $e) {
+            // Not xml
+        }
+
+        $json = json_decode($this->rawBody);
+
+        if (!is_null($json) && json_last_error() === JSON_ERROR_NONE) {
+            $this->contentType = self::CONTENT_TYPE_JSON;
+
+            return;
+        }
+
+        throw new ResponseException('Could not determine response content-type.');
+    }
+
+    /**
+     * Return valid response content types.
+     *
+     * @return string[]
+     */
+    public static function getSupportedContenTypes()
+    {
+        return array(
+            self::CONTENT_TYPE_JSON,
+            self::CONTENT_TYPE_XML,
+        );
+    }
+
+    /**
+     * Sets properties based on response body.
+     *
+     * @throws ResponseException
+     */
+    private function processRawBody()
+    {
+        switch ($this->contentType) {
+            case self::CONTENT_TYPE_JSON:
+
+                try {
+                    $response = ContentApiSdk::getValidJsonObj($this->rawBody);
+                } catch (InvalidDataException $e) {
+                    throw new ResponseException($e->getMessage(), $e->getCode(), $e);
+                }
+
+                $this->type = $response->_links->self->title;
+                $this->href = $response->_links->self->href;
+
+                if (property_exists($response, '_meta')) {
+                    $this->page = $response->_meta->page;
+                    $this->maxResults = $response->_meta->max_results;
+                    $this->total = $response->_meta->total;
+
+                    $this->nextPage = (property_exists($response->_links, 'next')) ? $this->page + 1 : $this->page;
+                    $this->prevPage = (property_exists($response->_links, 'prev')) ? $this->page - 1 : $this->page;
+                    // TODO: Check if casting to int is really required
+                    $this->lastPage = (property_exists($response->_links, 'last')) ? (int) ceil($this->total / $this->maxResults) : $this->page;
+
+                    $this->resources = $response->_items;
+                } else {
+                    $resourceObj = new stdClass();
+                    foreach ($response as $key => $value) {
+                        if (in_array($key, $this->metaKeys)) {
+                            continue;
+                        }
+
+                        $resourceObj->$key = $value;
+                    }
+
+                    $this->resources = $resourceObj;
+                }
+
+                break;
+            case self::CONTENT_TYPE_XML:
+
+                // TODO: Handle proper xml output
+                // throw new \Exception('Build in XML support!');
+                break;
+        }
+
+        return;
+    }
+
+    /**
+     * Returns content type.
+     *
+     * @return string
+     */
+    public function getContentType()
+    {
+        return $this->contentType;
+    }
+
+    /**
+     * Returns response type. Package or item.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Returns the response href. In most cases this is the request uri.
+     *
+     * @return string
+     */
+    public function getHref()
+    {
+        return $this->href;
+    }
+
+    /**
+     * Returns current page number.
+     *
+     * @return int
+     */
+    public function getCurrentPage()
+    {
+        return $this->page;
+    }
+
+    /**
+     * Returns next page number.
+     *
+     * @return int
+     */
+    public function getNextPage()
+    {
+        return $this->nextPage;
+    }
+
+    /**
+     * Returns previous page number.
+     *
+     * @return int
+     */
+    public function getPreviousPage()
+    {
+        return $this->prevPage;
+    }
+
+    /**
+     * Returns last page number.
+     *
+     * @return int
+     */
+    public function getLastPage()
+    {
+        return $this->lastPage;
+    }
+
+    /**
+     * Returns first page number.
+     *
+     * @return int
+     */
+    public function getFirstPage()
+    {
+        return 1;
+    }
+
+    /**
+     * Returns whether current page is last page.
+     *
+     * @return bool
+     */
+    public function isLastPage()
+    {
+        return $this->getCurrentPage() === $this->getLastPage();
+    }
+
+    /**
+     * Returns whether current page is first page.
+     *
+     * @return bool
+     */
+    public function isFirstPage()
+    {
+        return $this->getCurrentPage() === $this->getFirstPage();
+    }
+
+    /**
+     * Returns maximum results displayed per page.
+     *
+     * @return int
+     */
+    public function getMaxResults()
+    {
+        return $this->maxResults;
+    }
+
+    /**
+     * Returns total amount of results.
+     *
+     * @return int
+     */
+    public function getTotalResults()
+    {
+        return $this->total;
+    }
+
+    /**
+     * Returns the response resources, items or packages.
+     *
+     * @return array
+     */
+    public function getResources()
+    {
+        return $this->resources;
+    }
+}

--- a/src/Superdesk/ContentApiSdk/API/Response.php
+++ b/src/Superdesk/ContentApiSdk/API/Response.php
@@ -18,6 +18,8 @@ use Superdesk\ContentApiSdk\ContentApiSdk;
 use Superdesk\ContentApiSdk\Exception\ResponseException;
 use Superdesk\ContentApiSdk\Exception\InvalidDataException;
 use stdClass;
+use SimpleXMLElement;
+use Exception;
 
 /**
  * API Response object.
@@ -157,11 +159,11 @@ class Response
 
         // Try to determine content type based on body
         try {
-            $xml = new \SimpleXMLElement($this->rawBody);
+            $xml = new SimpleXMLElement($this->rawBody);
             $this->contentType = self::CONTENT_TYPE_XML;
 
             return;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             // Not xml
         }
 

--- a/src/Superdesk/ContentApiSdk/API/Response.php
+++ b/src/Superdesk/ContentApiSdk/API/Response.php
@@ -224,14 +224,12 @@ class Response
                 } else {
                     $resourceObj = new stdClass();
 
-                    if (is_array($responseJson) || $responseJson instanceof stdClass) {
-                        foreach ($responseJson as $key => $value) {
-                            if (in_array($key, $this->metaKeys)) {
-                                continue;
-                            }
-
-                            $resourceObj->$key = $value;
+                    foreach ($responseJson as $key => $value) {
+                        if (in_array($key, $this->metaKeys)) {
+                            continue;
                         }
+
+                        $resourceObj->$key = $value;
                     }
 
                     $this->resources = $resourceObj;

--- a/src/Superdesk/ContentApiSdk/Client/AbstractClient.php
+++ b/src/Superdesk/ContentApiSdk/Client/AbstractClient.php
@@ -14,20 +14,7 @@
 
 namespace Superdesk\ContentApiSdk\Client;
 
-use Superdesk\ContentApiSdk\API\Request;
-use Superdesk\ContentApiSdk\API\Response;
-
-/**
- * Interface for clients.
- */
-interface ClientInterface
+abstract class AbstractClient implements ClientInterface
 {
-    /**
-     * Makes a call to the public api and returns a response.
-     *
-     * @param  Request $request
-     *
-     * @return Response
-     */
-    public function makeApiCall(Request $request);
+
 }

--- a/src/Superdesk/ContentApiSdk/Client/AbstractClient.php
+++ b/src/Superdesk/ContentApiSdk/Client/AbstractClient.php
@@ -16,5 +16,4 @@ namespace Superdesk\ContentApiSdk\Client;
 
 abstract class AbstractClient implements ClientInterface
 {
-
 }

--- a/src/Superdesk/ContentApiSdk/Client/FileGetContentsClient.php
+++ b/src/Superdesk/ContentApiSdk/Client/FileGetContentsClient.php
@@ -46,13 +46,23 @@ class FileGetContentsClient implements ClientInterface
     protected $helper;
 
     /**
+     * Configuration object.
+     *
+     * @var array
+     */
+    protected $config = array();
+
+    /**
      * Initialize object
      *
      * @param FileGetContentsClientHelper $helper
      */
-    public function __construct(FileGetContentsClientHelper $helper)
+    public function __construct(FileGetContentsClientHelper $helper, array $config = null)
     {
         $this->helper = $helper;
+        if (is_array($config)) {
+            $this->config = $config;
+        }
     }
 
     /**

--- a/src/Superdesk/ContentApiSdk/Client/FileGetContentsClient.php
+++ b/src/Superdesk/ContentApiSdk/Client/FileGetContentsClient.php
@@ -88,7 +88,7 @@ class FileGetContentsClient implements ClientInterface
      */
     private function getBaseUrl()
     {
-        return rtrim($this->config['base_uri'], '/');
+        return sprintf('%s/%s', rtrim($this->config['base_uri'], '/'), ContentApiSdk::getVersionURL());
     }
 
     /**

--- a/src/Superdesk/ContentApiSdk/Client/FileGetContentsClientHelper.php
+++ b/src/Superdesk/ContentApiSdk/Client/FileGetContentsClientHelper.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the PHP SDK library for the Superdesk Content API.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace Superdesk\ContentApiSdk\Client;
+
+use Superdesk\ContentApiSdk\API\Request;
+use Superdesk\ContentApiSdk\Exception\ClientException;
+
+/**
+ * Helper class for FileGetContentsClient
+ */
+class FileGetContentsClientHelper
+{
+    /**
+     * Send actual request and return raw response data.
+     *
+     * @param string $url Url for file_get_contents
+     * @param array $options Options for stream_context_create
+     *
+     * @return array Returns an array container headers and body or the response.
+     */
+    public function sendRequest($url, $options)
+    {
+        $context = stream_context_create($options);
+
+        // Silence error, we'll throw an exception on an invalid response
+        $response = @file_get_contents(
+            $url,
+            false,
+            $context
+        );
+        if ($response === false) {
+            $lastError = error_get_last();
+            throw new ClientException(sprintf('%s (%s)', 'Invalid response.', $lastError['message']), $lastError['type']);
+        }
+
+        return array('headers' => $http_response_header, 'body' => (string) $response);
+    }
+}

--- a/src/Superdesk/ContentApiSdk/Client/FileGetContentsClientHelper.php
+++ b/src/Superdesk/ContentApiSdk/Client/FileGetContentsClientHelper.php
@@ -29,6 +29,8 @@ class FileGetContentsClientHelper
      * @param array $options Options for stream_context_create
      *
      * @return array Returns an array container headers and body or the response.
+     *
+     * @throws ClientException When the reponse did non succeed
      */
     public function sendRequest($url, $options)
     {

--- a/src/Superdesk/ContentApiSdk/ContentApiSdk.php
+++ b/src/Superdesk/ContentApiSdk/ContentApiSdk.php
@@ -27,9 +27,25 @@ use stdClass;
  */
 class ContentApiSdk
 {
+    /**
+     * Items endpoint
+     */
     const SUPERDESK_ENDPOINT_ITEMS = '/items';
+
+    /**
+     * Package endpoint
+     */
     const SUPERDESK_ENDPOINT_PACKAGES = '/packages';
+
+    /**
+     * Type indication for packages
+     */
     const PACKAGE_TYPE_COMPOSITE = 'composite';
+
+    /**
+     * Supported API version by this SDK version
+     */
+    const API_VERSION = 1;
 
     /**
      * A list of parameters the Content API accepts.
@@ -356,5 +372,15 @@ class ContentApiSdk
         }
 
         return $jsonObj;
+    }
+
+    /**
+     * Returns version of api for creating verioned url.
+     *
+     * @return string
+     */
+    public static function getVersionURL()
+    {
+        return sprintf('v%d', self::API_VERSION);
     }
 }

--- a/src/Superdesk/ContentApiSdk/ContentApiSdk.php
+++ b/src/Superdesk/ContentApiSdk/ContentApiSdk.php
@@ -210,7 +210,7 @@ class ContentApiSdk
      *
      * @param array $params Filter parameters
      *
-     * @return mixed
+     * @return ResourceCollection
      */
     public function getItems($params)
     {
@@ -262,7 +262,7 @@ class ContentApiSdk
      * @param bool  $resolveItems Inject full associations recursively instead
      *                            of references by uri.
      *
-     * @return mixed
+     * @return ResourceCollection
      */
     public function getPackages($params, $resolveAssociations = false)
     {

--- a/src/Superdesk/ContentApiSdk/ContentApiSdk.php
+++ b/src/Superdesk/ContentApiSdk/ContentApiSdk.php
@@ -22,6 +22,7 @@ use Superdesk\ContentApiSdk\API\Pagerfanta\ResourceCollection;
 use Superdesk\ContentApiSdk\Client\ClientInterface;
 use Superdesk\ContentApiSdk\Data\Item;
 use Superdesk\ContentApiSdk\Data\Package;
+use Superdesk\ContentApiSdk\Exception\ClientException;
 use Superdesk\ContentApiSdk\Exception\ContentApiException;
 use Superdesk\ContentApiSdk\Exception\InvalidArgumentException;
 use Superdesk\ContentApiSdk\Exception\InvalidDataException;
@@ -278,8 +279,8 @@ class ContentApiSdk
         $page = (isset($params['page'])) ? $params['page'] : 1;
         $maxResults = (isset($params['max_results'])) ? $params['max_results'] : 25;
 
-        $packageCollection->setPage($page);
-        $packageCollection->setMaxResults($maxResults);
+        $packageCollection->setCurrentPage($page);
+        $packageCollection->setMaxPerPage($maxResults);
 
         return $packageCollection;
     }

--- a/src/Superdesk/ContentApiSdk/ContentApiSdk.php
+++ b/src/Superdesk/ContentApiSdk/ContentApiSdk.php
@@ -233,13 +233,13 @@ class ContentApiSdk
     /**
      * Get package by identifier.
      *
-     * @param string $packageId    Package identifier
-     * @param bool   $resolveItems Inject full associations recursively instead
-     *                             of references by uri.
+     * @param string $packageId Package identifier
+     * @param bool   $resolveAssociations Inject full associations recursively
+     *                                    instead of references by uri.
      *
      * @return Package
      */
-    public function getPackage($packageId, $resolveItems = false)
+    public function getPackage($packageId, $resolveAssociations = false)
     {
         $request = $this->getNewRequest(sprintf('%s/%s', self::SUPERDESK_ENDPOINT_PACKAGES, $packageId));
         $response = $this->client->makeApiCall($request);
@@ -247,7 +247,7 @@ class ContentApiSdk
         $package = new Package($response->getResources());
 
         // This can be removed once the API fully supports retrieving package associations
-        if ($resolveItems) {
+        if ($resolveAssociations) {
             $associations = $this->getAssociationsFromPackage($package);
             $package = $this->injectAssociations($package, $associations);
         }
@@ -258,9 +258,9 @@ class ContentApiSdk
     /**
      * Get multiple packages based on a filter.
      *
-     * @param array $params       Filter parameters
-     * @param bool  $resolveItems Inject full associations recursively instead
-     *                            of references by uri.
+     * @param array $params Filter parameters
+     * @param bool  $resolveAssociations Inject full associations recursively
+     *                                   instead of references by uri.
      *
      * @return ResourceCollection
      */
@@ -291,7 +291,7 @@ class ContentApiSdk
      *
      * @return stdClass List of associations
      */
-    private function getAssociationsFromPackage(Package $package)
+    public function getAssociationsFromPackage(Package $package)
     {
         $associations = new stdClass();
 
@@ -335,7 +335,7 @@ class ContentApiSdk
      *
      * @return Package Package with data injected
      */
-    private function injectAssociations(Package $package, stdClass $associations)
+    public function injectAssociations(Package $package, stdClass $associations)
     {
         if (count($package->associations) > 0 && count($associations) > 0) {
             $package->associations = $associations;

--- a/src/Superdesk/ContentApiSdk/Exception/ClientException.php
+++ b/src/Superdesk/ContentApiSdk/Exception/ClientException.php
@@ -12,22 +12,11 @@
  * @license http://www.superdesk.org/license
  */
 
-namespace Superdesk\ContentApiSdk\Client;
-
-use Superdesk\ContentApiSdk\API\Request;
-use Superdesk\ContentApiSdk\API\Response;
+namespace Superdesk\ContentApiSdk\Exception;
 
 /**
- * Interface for clients.
+ * Client exception for the API.
  */
-interface ClientInterface
+class ClientException extends ContentApiException
 {
-    /**
-     * Makes a call to the public api and returns a response.
-     *
-     * @param  Request $request
-     *
-     * @return Response
-     */
-    public function makeApiCall(Request $request);
 }

--- a/src/Superdesk/ContentApiSdk/Exception/RequestException.php
+++ b/src/Superdesk/ContentApiSdk/Exception/RequestException.php
@@ -12,22 +12,11 @@
  * @license http://www.superdesk.org/license
  */
 
-namespace Superdesk\ContentApiSdk\Client;
-
-use Superdesk\ContentApiSdk\API\Request;
-use Superdesk\ContentApiSdk\API\Response;
+namespace Superdesk\ContentApiSdk\Exception;
 
 /**
- * Interface for clients.
+ * Request exception for the API.
  */
-interface ClientInterface
+class RequestException extends ContentApiException
 {
-    /**
-     * Makes a call to the public api and returns a response.
-     *
-     * @param  Request $request
-     *
-     * @return Response
-     */
-    public function makeApiCall(Request $request);
 }

--- a/src/Superdesk/ContentApiSdk/Exception/ResponseException.php
+++ b/src/Superdesk/ContentApiSdk/Exception/ResponseException.php
@@ -12,22 +12,11 @@
  * @license http://www.superdesk.org/license
  */
 
-namespace Superdesk\ContentApiSdk\Client;
-
-use Superdesk\ContentApiSdk\API\Request;
-use Superdesk\ContentApiSdk\API\Response;
+namespace Superdesk\ContentApiSdk\Exception;
 
 /**
- * Interface for clients.
+ * Response exception for the API.
  */
-interface ClientInterface
+class ResponseException extends ContentApiException
 {
-    /**
-     * Makes a call to the public api and returns a response.
-     *
-     * @param  Request $request
-     *
-     * @return Response
-     */
-    public function makeApiCall(Request $request);
 }


### PR DESCRIPTION
API collections (items & packages) results are now paginatable via the
Pagerfanta library. This should make it easy to retrieve all data for
certain parameters. Single data (item & package) are not paginatable.

Further there are now Request and Response objects which communicate
internally with the HTTP Client, which should make handling of this more
easy.
